### PR TITLE
README.md: Don't require a github account to clone repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Make sure the docker daemon is running. If it is you can run these commands to g
 ```
 $ python3 -m venv ternenv
 $ cd ternenv
-$ git clone git@github.com:vmware/tern.git
+$ git clone https://github.com/vmware/tern.git
 $ source bin/activate
 $ cd tern
 $ pip install -r requirements.txt
@@ -37,7 +37,7 @@ WARNING: Tern is meant to give guidance on what may be installed for each line i
 ```
 $ cd ternenv
 $ source bin/activate
-$ git clone git@github.com:vmware/tern.git
+$ git clone https://github.com/vmware/tern.git
 $ cd tern
 $ export PYTHONPATH=`pwd`
 $ python tests/<test file>.py


### PR DESCRIPTION
Change example git clone usage to use
https://github.com/vmware/tern.git as people can do that without a
github account.

Signed-off-by: John L. Villalovos <john@sodarock.com>