### PR TITLE
Gracefully exit if the docker daemon is not running

### DIFF
--- a/tern
+++ b/tern
@@ -10,6 +10,8 @@ import logging
 import os
 import report
 from common import clear_cache
+import subprocess
+import sys
 '''
 Tern executable
 '''
@@ -37,6 +39,12 @@ def main(args, logger):
 
 
 if __name__ == '__main__':
+
+    try:
+        docker_is_running = subprocess.check_output('docker ps', shell=True)
+    except subprocess.CalledProcessError as docker:
+        print('Docker daemon is not running. Error code', docker.returncode)
+        sys.exit()
 
     def check_file_existence(path):
         if not os.path.isfile(path):


### PR DESCRIPTION
This will check whether docker is running or not through the subprocess module. I have used the check_output method which is using "docker ps" command to check whether docker daemon is running or not. If docker is not running then subprocess module raises the ProcessError exception which is being used to raise the customized message on the console and gracefully exit the script. 

Resolves: #28