### PR TITLE
Convert short names of modules to the full name

### DIFF
--- a/common.py
+++ b/common.py
@@ -8,7 +8,7 @@ import logging
 from classes.package import Package
 from classes.notice import Notice
 from classes.command import Command
-from command_lib import command_lib as cmdlib
+from command_lib import command_lib
 from report import formats
 from report import errors
 from report import content
@@ -85,14 +85,14 @@ def add_base_packages(image):
         3. Create a list of packages
         4. Add them to the image'''
     # information under the base image tag in the command library
-    listing = cmdlib.get_base_listing(image.name, image.tag)
+    listing = command_lib.get_base_listing(image.name, image.tag)
     # create the origin for the base image
     origin_info = formats.invoking_base_commands + '\n' + \
         content.print_base_invoke(image.name, image.tag)
     image.origins.add_notice_origin(origin_info)
     origin_str = 'command_lib/base.yml'
     if listing:
-        shell, msg = cmdlib.get_image_shell(listing)
+        shell, msg = command_lib.get_image_shell(listing)
         if not shell:
             # add a warning notice for no shell in the command library
             logger.warning('No shell listing in command library. '
@@ -114,13 +114,13 @@ def add_base_packages(image):
         # for now, we add the list of packages to all the layers in a
         # starting base image
         if check_container():
-            names, n_msg = cmdlib.get_pkg_attr_list(
+            names, n_msg = command_lib.get_pkg_attr_list(
                 shell, listing['names'])
-            versions, v_msg = cmdlib.get_pkg_attr_list(
+            versions, v_msg = command_lib.get_pkg_attr_list(
                 shell, listing['versions'])
-            licenses, l_msg = cmdlib.get_pkg_attr_list(
+            licenses, l_msg = command_lib.get_pkg_attr_list(
                 shell, listing['licenses'])
-            src_urls, u_msg = cmdlib.get_pkg_attr_list(
+            src_urls, u_msg = command_lib.get_pkg_attr_list(
                 shell, listing['src_urls'])
             # add a notice to the image if something went wrong
             invoke_msg = n_msg + v_msg + l_msg + u_msg
@@ -157,10 +157,10 @@ def fill_package_metadata(pkg_obj, pkg_listing, shell):
     # create a NoticeOrigin for the package
     origin_str = 'command_lib/snippets.yml'
     # version
-    version_listing, listing_msg = cmdlib.check_library_key(
+    version_listing, listing_msg = command_lib.check_library_key(
         pkg_listing, 'version')
     if version_listing:
-        version_list, invoke_msg = cmdlib.get_pkg_attr_list(
+        version_list, invoke_msg = command_lib.get_pkg_attr_list(
             shell, version_listing, package_name=pkg_obj.name)
         if version_list:
             pkg_obj.version = version_list[0]
@@ -171,10 +171,10 @@ def fill_package_metadata(pkg_obj, pkg_listing, shell):
         pkg_obj.origins.add_notice_to_origins(
             origin_str, Notice(listing_msg, 'warning'))
     # license
-    license_listing, listing_msg = cmdlib.check_library_key(
+    license_listing, listing_msg = command_lib.check_library_key(
         pkg_listing, 'license')
     if license_listing:
-        license_list, invoke_msg = cmdlib.get_pkg_attr_list(
+        license_list, invoke_msg = command_lib.get_pkg_attr_list(
             shell, license_listing, package_name=pkg_obj.name)
         if license_list:
             pkg_obj.license = license_list[0]
@@ -185,10 +185,10 @@ def fill_package_metadata(pkg_obj, pkg_listing, shell):
         pkg_obj.origins.add_notice_to_origins(
             origin_str, Notice(listing_msg, 'warning'))
     # src_urls
-    url_listing, listing_msg = cmdlib.check_library_key(
+    url_listing, listing_msg = command_lib.check_library_key(
         pkg_listing, 'license')
     if url_listing:
-        url_list, invoke_msg = cmdlib.get_pkg_attr_list(
+        url_list, invoke_msg = command_lib.get_pkg_attr_list(
             shell, url_listing, package_name=pkg_obj.name)
         if url_list:
             pkg_obj.src_url = url_list[0]
@@ -204,9 +204,9 @@ def get_package_dependencies(package_listing, package_name, shell):
     '''The package listing is the result of looking up the command name in the
     command library. Given this listing, the package name and the shell
     return a list of package dependency names'''
-    deps_listing, deps_msg = cmdlib.check_library_key(package_listing, 'deps')
+    deps_listing, deps_msg = command_lib.check_library_key(package_listing, 'deps')
     if deps_listing:
-        deps_list, invoke_msg = cmdlib.get_pkg_attr_list(
+        deps_list, invoke_msg = command_lib.get_pkg_attr_list(
             shell, deps_listing, package_name=package_name)
         if deps_list:
             return list(set(deps_list)), ''
@@ -268,7 +268,7 @@ def filter_install_commands(shell_command_line):
     report = ''
     command_list = get_shell_commands(shell_command_line)
     for command in command_list:
-        cmdlib.set_command_attrs(command)
+        command_lib.set_command_attrs(command)
     ignore_msgs, filter1 = remove_ignored_commands(command_list)
     unrec_msgs, filter2 = remove_unrecognized_commands(filter1)
     if ignore_msgs:

--- a/report/content.py
+++ b/report/content.py
@@ -3,12 +3,13 @@ Copyright (c) 2017 VMware, Inc. All Rights Reserved.
 SPDX-License-Identifier: BSD-2-Clause
 '''
 
-import command_lib.command_lib as cmdlib
+import command_lib.command_lib
 from report import formats
 
 '''
 Functions to generate content for the report
 '''
+
 
 def print_invoke_list(info_dict, info):
     '''Print out the list of command snippets that get invoked to retrive
@@ -34,7 +35,7 @@ def print_invoke_list(info_dict, info):
 def print_base_invoke(base_image, base_tag):
     '''Given the base image and tag in a tuple return a string containing
     the command_lib/base.yml'''
-    info = cmdlib.get_base_listing(base_image, base_tag)
+    info = command_lib.command_lib.get_base_listing(base_image, base_tag)
     report = ''
     report = report + print_invoke_list(info, 'names')
     report = report + print_invoke_list(info, 'versions')
@@ -49,7 +50,7 @@ def print_package_invoke(command_name):
     package name, return a string with the list of commands that will be
     invoked in the container'''
     report = ''
-    command_listing = cmdlib.get_command_listing(command_name)
+    command_listing = command_lib.command_lib.get_command_listing(command_name)
     if command_listing:
         pkg_list = command_listing['packages']
         for pkg_dict in pkg_list:

--- a/report/report.py
+++ b/report/report.py
@@ -15,7 +15,7 @@ from classes.image import Image
 from classes.image_layer import ImageLayer
 from classes.notice import Notice
 from classes.package import Package
-from command_lib import command_lib as cmdlib
+from command_lib import command_lib
 import common
 import docker
 
@@ -25,6 +25,7 @@ Create a report
 
 # global logger
 logger = logging.getLogger(constants.logger_name)
+
 
 def write_report(report):
     '''Write the report to a file'''
@@ -126,7 +127,6 @@ def generate_report(args, *images):
     write_report(report)
 
 
-
 def execute_dockerfile(args):
     '''Execution path if given a dockerfile'''
     logger.debug('Setting up...')
@@ -155,8 +155,8 @@ def execute_dockerfile(args):
         # This step actually needs to go to the beginning but since
         # there is no way of tracking imported images from within
         # the docker image history, we build after importing the base image
-        shell, msg = cmdlib.get_image_shell(
-            cmdlib.get_base_listing(base_image.name, base_image.tag))
+        shell, msg = command_lib.get_image_shell(
+            command_lib.get_base_listing(base_image.name, base_image.tag))
         if not shell:
             shell = constants.shell
         logger.debug('Building image...')

--- a/tests/test_util_commands.py
+++ b/tests/test_util_commands.py
@@ -5,22 +5,22 @@ SPDX-License-Identifier: BSD-2-Clause
 
 import unittest
 
-import utils.commands as cmds
-import utils.metadata as md
+import utils.commands
+import utils.metadata
 
 
 class TestUtilCommands(unittest.TestCase):
 
     def setUp(self):
-        cmds.docker_command(cmds.pull, 'debian:jessie')
+        utils.commands.docker_command(utils.commands.pull, 'debian:jessie')
 
     def testImageMetadata(self):
-        self.assertTrue(cmds.extract_image_metadata('debian:jessie'))
-        self.assertFalse(cmds.extract_image_metadata('repo:tag'))
+        self.assertTrue(utils.commands.extract_image_metadata('debian:jessie'))
+        self.assertFalse(utils.commands.extract_image_metadata('repo:tag'))
 
     def tearDown(self):
-        cmds.remove_image('debian:jessie')
-        md.clean_temp()
+        utils.commands.remove_image('debian:jessie')
+        utils.metadata.clean_temp()
 
 
 if __name__ == '__main__':

--- a/tests/test_util_metadata.py
+++ b/tests/test_util_metadata.py
@@ -5,25 +5,25 @@ SPDX-License-Identifier: BSD-2-Clause
 
 import unittest
 
-import utils.commands as cmds
-import utils.metadata as md
+import utils.commands
+import utils.metadata
 
 
 class TestUtilCommands(unittest.TestCase):
 
     def setUp(self):
-        cmds.docker_command(cmds.pull, 'debian:jessie')
-        cmds.extract_image_metadata('debian:jessie')
+        utils.commands.docker_command(utils.commands.pull, 'debian:jessie')
+        utils.commands.extract_image_metadata('debian:jessie')
 
     def testImageMetadata(self):
-        manifest = md.get_image_manifest()
+        manifest = utils.metadata.get_image_manifest()
         self.assertTrue(manifest)
-        layers = md.get_image_layers(manifest)
+        layers = utils.metadata.get_image_layers(manifest)
         self.assertEqual(len(layers), 1)
 
     def tearDown(self):
-        cmds.remove_image('debian:jessie')
-        md.clean_temp()
+        utils.commands.remove_image('debian:jessie')
+        utils.metadata.clean_temp()
 
 
 if __name__ == '__main__':

--- a/verify_invoke.py
+++ b/verify_invoke.py
@@ -6,7 +6,7 @@ SPDX-License-Identifier: BSD-2-Clause
 import argparse
 import subprocess
 
-import utils.commands as cmds
+import utils.commands
 from common import check_for_unique_package
 
 '''
@@ -19,7 +19,7 @@ produce expected results
 def look_up_lib(keys):
     '''Return the dictionary for the keys given
     Assuming that the keys go in order'''
-    subd = cmds.command_lib[keys.pop(0)]
+    subd = utils.commands.command_lib[keys.pop(0)]
     while keys:
         subd = subd[keys.pop(0)]
     return subd
@@ -32,7 +32,7 @@ if __name__ == '__main__':
         a container produce expected results.
         Give a list of keys to point to in the command library and the
         image''')
-    parser.add_argument('--container', default=cmds.container,
+    parser.add_argument('--container', default=utils.commands.container,
                         help='Name of the running container')
     parser.add_argument('--keys', nargs='+',
                         help='List of keys to look up in the command library')
@@ -52,7 +52,7 @@ if __name__ == '__main__':
     else:
         info_dict = look_up_lib(args.keys)
     try:
-        result = cmds.get_pkg_attr_list(
+        result = utils.commands.get_pkg_attr_list(
             args.shell, info_dict, args.package, args.container)
         print(result)
         print(len(result))


### PR DESCRIPTION
Converted short names of modules to the full name to improve readability.
For example, _from utils import dockerfile as df_ >> _from utils import dockerfile_.

Changed global variable _dockerfile_ to _dockerfile_global_, because line
_from utils import dockerfile as df_ was changed to _from utils import dockerfile_.

Resolves issue #29.

Signed-off-by: Vlad Nalimov vlad.nalimov@gmail.com