### PR TITLE
Gracefully exit if the docker daemon is not running

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-### Contributing to the Tern project
+# Contributing to the Tern project
 
 Once again, we hope you have read our [code of conduct](/CODE_OF_CONDUCT.md) before starting.
 
@@ -11,19 +11,26 @@ You can contribute in the following ways:
 * Improving the Unit and Functional Tests
 * Improving the Core Project
 
-### Skills for contributing
+## Skills for contributing
 
 * English (not necessarily fluent but workable)
 * Python (a working knowledge of object oriented Python would be nice, but if you know how python functions/modules work, this is enough to get you started)
 * YAML (Tern uses yaml files heavily for data lookup. An overview of YAML can be found [here](http://yaml.org/))
 
-### Keeping in touch
+## Keeping in touch
 
 If you would like to ask a question or start a discussion, post a topic on the [public forum](https://groups.google.com/forum/#!forum/tern-discussion). You will need to apply to join the group before posting. We will respond to your question or topic within three days unless the post was over the weekend in which case we may take longer to respond. This is our primary communication channel so it is highly likely that you will get a response here.
 
 If you would like to chat live, you can join the [slack channel](https://vmwarecode.slack.com/messages/tern). If you don't have an @vmware.com or @emc.com email, please click [here](https://code.vmware.com/join), enter your email address and click "Request Invite". Although we monitor the channel, we may not respond right away and if the same question was asked on the forum, we will choose to respond there.
 
-### An overview of the contribution lifecycle
+## Learn about Tern
+
+- [FAQ](/docs/faq.md)
+- [Glossary](/docs/glossary.md)
+- [Architecture](/docs/architecture.md)
+- [Navigating the Code](/docs/navigating-the-code.md)
+
+## An overview of the contribution lifecycle
 
 Once you decide that you would like to play around with the project
 
@@ -46,7 +53,7 @@ Expect to spend time resolving conflicts here.
 8. A reviewer will further communicate with you through the PR.
 9. If everything looks good the PR will be accepted.
 
-### Commit message format
+## Commit message format
 
 The commit message of your PR should be able to communicate what problem/opportunity the PR addresses without any reference to forum messages or discussions on slack or IRL. You may make a reference to a github issue number using the github format (eg: Resolves: #1). Here is an overview of what is needed in a good commit message taken from [this blog](https://chris.beams.io/posts/git-commit/)
 
@@ -101,7 +108,7 @@ See also: #456, #789
 
 Signed-off-by: Some Dev <somedev@example.com>
 ```
-### Filing an Issue
+## Filing an Issue
 
 You may file an issue through the github issue tracker. Please follow the same guidelines as the commit message guidelines when formatting your issue. Please make sure to include the following for quick debugging and resolution:
 
@@ -113,7 +120,7 @@ You may file an issue through the github issue tracker. Please follow the same g
 
 You may file an issue and create a PR that references said issue. This, however, does not guarantee acceptance of the PR. Contributing in this way works for small bug or documentation fixes but doesn't lend itself well to large updates. We encourage you to start a discussion on the forum. Typically a follow up issue will be created referencing the topic.
 
-### Troubleshooting
+## Troubleshooting
 
 * Tern produces a generic message about being unable to execute a docker command with a CalledProcessError from the get go: Make sure the docker daemon is running first
 * Unable to find module 'yaml': make sure to activate the python virtualenv first and then run pip install -r requirements.txt 

--- a/README.md
+++ b/README.md
@@ -1,21 +1,31 @@
 ![Tern](/docs/img/tern_logo.png)
 
-### Welcome to the Tern Project
+# Welcome to the Tern Project
 
-Tern is a tool to find the metadata for packages installed in Docker containers, specifically the sources, versions and licenses. It does this by looking up
-a "command library" for code snippets to execute in a running container. The command library is a list of commands used to install and remove packages
-(such as a package manager) with associated shell commands to run within the container to retrieve specific information.
+Tern is an inspection tool to find the metadata of the packages installed in a container image. It runs scripts from the "command library" against the container and collates the information into a Bill of Materials (BOM) report. Tern gives you a deeper understanding of your container's bill of materials so you can make better decisions about your container based infrastructure, integration and deployment strategies.
 
-Tern was created to help developers meet open source compliance requirements for containers. Tools like Docker make it easy to build and distribute containers but keeping track of what is installed is left to developer or devops teams. Tern aims to bridge this gap.
+## Why Tern?
+Tern was created to help developers meet open source compliance requirements for containers. Tools like Docker make it easy to build and distribute containers but keeping track of what is installed in the container is left to dev or devops teams. Knowing your container's Bill of Materials not only helps you meet your open source compliance obligations, but helps you debug integration and build errors and identify vulnerable packages in your running containers easily.
 
-### Try it out
+## Table of Contents
+- [Getting Started](#getting-started)
+- [Project Status](#project-status)
+- [Contributing](#contributing)
 
-#### Requirements
+## Getting Started<a name="getting-started"/>
+
+### Requirements
+Tern is currently developed on a Linux distro with a kernel version >= 4.0. Possible development distros are Ubuntu 16.04 or newer or Fedora 25 or newer.
+Install the following:
 - Git (Installation instructions can be found here: https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
-- Docker CE (Installation instructions can be found here: https://docs.docker.com/engine/installation/#server)
 - Python 3.6.2 (sudo apt-get install python3.6 or sudo dnf install python36)
 
-Make sure the docker daemon is running. If it is you can run these commands to get you started:
+If you happen to be using Docker containers
+- Docker CE (Installation instructions can be found here: https://docs.docker.com/engine/installation/#server)
+
+Make sure the docker daemon is running.
+
+
 ```
 $ python3 -m venv ternenv
 $ cd ternenv
@@ -25,15 +35,16 @@ $ cd tern
 $ pip install -r requirements.txt
 $ ./tern report -d samples/photon_git/Dockerfile
 ```
+
 Take a look at report.txt to see what packages are installed in the created Docker image and how Tern got this information. Feel free to try this out on the other sample Dockerfiles in the samples directory or on Dockerfiles you may be working with.
 
-#### To get a summary report
+### To get a summary report
 ```
 $ ./tern report -s -d samples/photon_git_Dockerfile
 ```
 WARNING: Tern is meant to give guidance on what may be installed for each line in a Dockerfile so it is recommended that for the purpose of investigation, the default report is used. The summary report may be used as the output of a build artifact or something to submit to a compliance or legal team.
 
-#### To run a test
+### To run a test
 ```
 $ cd ternenv
 $ source bin/activate
@@ -42,7 +53,7 @@ $ cd tern
 $ export PYTHONPATH=`pwd`
 $ python tests/<test file>.py
 ```
-### Project Status
+## Project Status<a name="project-status"/>
 
 Tern currently has these features:
 * A Cache to store layers with the packages that are installed in those layers
@@ -55,10 +66,10 @@ Current work:
 * Layering of container filesystems one by one
 * Source retrieval
 
-### Documentation
+## Documentation
 Architecture, function blocks, code descriptions and the project roadmap are located on the Wiki. Feel free to use it as a guide to usage and development. We also welcome contributions to the documentation. See the [contributing guide](/CONTRIBUTING.md) to find out how to submit changes.
 
-### Get Involved
+## Get Involved<a name="contributing"/>
 
 Do you have questions about Tern? Do you think it can do better? Would you like to make it better? You can get involved by giving your feedback and contributing to the code, documentation and conversation!
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,11 @@
 
 Tern is an inspection tool to find the metadata of the packages installed in a container image. It runs scripts from the "command library" against the container and collates the information into a Bill of Materials (BOM) report. Tern gives you a deeper understanding of your container's bill of materials so you can make better decisions about your container based infrastructure, integration and deployment strategies.
 
-## Why Tern?
-Tern was created to help developers meet open source compliance requirements for containers. Tools like Docker make it easy to build and distribute containers but keeping track of what is installed in the container is left to dev or devops teams. Knowing your container's Bill of Materials not only helps you meet your open source compliance obligations, but helps you debug integration and build errors and identify vulnerable packages in your running containers easily.
-
 ## Table of Contents
+- [FAQ](/docs/faq.md)
 - [Getting Started](#getting-started)
 - [Project Status](#project-status)
-- [Documentation](#documetation)
+- [Documentation](#documentation)
 - [Contributing](#contributing)
 - [Glossary of Terms](/docs/glossary.md)
 - [Architecture](/docs/architecture.md)
@@ -59,16 +57,7 @@ $ python tests/<test file>.py
 ```
 ## Project Status<a name="project-status"/>
 
-Tern currently has these features:
-* A Cache to store layers with the packages that are installed in those layers
-* A report containing a line-by-line 'walkthrough' of the Dockerfile to say what packages were installed in each line
-* A summary report
-* The complete list of dependencies are retrieved
-
-Current work:
-* Code refactoring
-* Layering of container filesystems one by one
-* Source retrieval
+We try to keep the [project roadmap](./docs/project-roadmap.md) as up to date as possible. We are currently working on Release 0.1.0.
 
 ## Documentation<a name="documentation"/>
 Architecture, function blocks, code descriptions and the project roadmap are located in the docs folder. We also welcome contributions to the documentation. See the [contributing guide](/CONTRIBUTING.md) to find out how to submit changes.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@ Tern was created to help developers meet open source compliance requirements for
 ## Table of Contents
 - [Getting Started](#getting-started)
 - [Project Status](#project-status)
+- [Documentation](#documetation)
 - [Contributing](#contributing)
+- [Glossary of Terms](/docs/glossary.md)
+- [Architecture](/docs/architecture.md)
+- [Navigating the Code](/docs/navigating-the-code.md)
 
 ## Getting Started<a name="getting-started"/>
 
@@ -66,8 +70,8 @@ Current work:
 * Layering of container filesystems one by one
 * Source retrieval
 
-## Documentation
-Architecture, function blocks, code descriptions and the project roadmap are located on the Wiki. Feel free to use it as a guide to usage and development. We also welcome contributions to the documentation. See the [contributing guide](/CONTRIBUTING.md) to find out how to submit changes.
+## Documentation<a name="documentation"/>
+Architecture, function blocks, code descriptions and the project roadmap are located in the docs folder. We also welcome contributions to the documentation. See the [contributing guide](/CONTRIBUTING.md) to find out how to submit changes.
 
 ## Get Involved<a name="contributing"/>
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,40 @@
+# Tern Architecture
+
+You may want to look at the [glossary](./docs/glossary.md) to understand the terms being used.
+
+## Overall Approach
+The general approach to finding package metadata given some files is to perform static analysis on the files. Tern's approach is more brute force - using the same tools that were used to install a package to retrieve the status of the package. This involves spinning up a container and running shell commands against it. The results of the shell commands are then collated into a nice report showing which container layers brought in what packages. For compliance purposes (as Tern is a compliance tool), shell scripts retrieving package versions, licenses and source urls are used. Tern is also built to be a tool for guidance, and to that effect it is opinionated. For example, if it cannot find information about licenses, it will inform you of this and nudge you to either add information about it or a shell script to retrieve it.
+
+## Guiding Principles
+1. OSS Compliance First: Tern is a compliance tool at heart. Hence whatever it does is meant to help the user meet their open source compliance obligations, or, at the minimum, make them aware of the licenses governing the open source software they use.
+2. Be Transparent: Tern will report on everything it is doing in order to not mislead on how it got its information
+3. Inform not Ignore: Tern will report on all exceptions it has encountered during the course of its execution
+
+## Layout
+There are 3 sections that operate together:
+
+### The Cache
+This is the database where filesystem identifiers can be queried against to retrieve package information. This is useful as many containers are based on other container images. If Tern had come across the same filesystem in another container, it can retrieve the package information without spinning up a container. Tern looks for filesystems here before spinning up a container for analysis.
+
+### The Command Library
+This is a database of shell commands that may be used to create a container's layer filesystem. There are two types of shell commands - one for base images and one for standalone shell commands. The library is split in this way to account for situations where whole root filesystems are imported in order to create a new container.
+
+For example, in [this Dockerfile sample](./samples/debian_vim/Dockerfile), the use of FROM debian:jessie imports the base debian:jessie image from Dockerhub. This image is in turn created with a [Dockerfile](https://github.com/debuerreotype/docker-debian-artifacts/blob/b024a792c752a5c6ccc422152ab0fd7197ae8860/jessie/Dockerfile) that has the FROM scratch directive and adds an entire root filesystem created from an external build an release pipeline not related to Docker. The base library is meant to keep track of such images. On the other hand, the snippets library is used to keep track of standalone shell commands that can be used to install packages, once you hava a base image to work on.
+
+Some acknowledgement should be made here that this is not the only way to create a container. However, it seems to be the most prevalent way and a way that makes sense to most people creating containers and tools like Docker allow for this to be done easily.
+
+### The Reporting
+Tern's main purpose is to produce reports, either as an aid for understanding a container image or as a manifest for something else to consume. The default is the verbose report explaining where in the container the list of packages came from and what commands created them. The easiest format to consume is actually cache.yml that only contains the filesystem layer identifier and the list of packages installed in it. Support for other types of formats are available using format converters. A summary text format is also available containing just the packages installed.
+
+## Objects
+Tern uses classes to encapsulate some of the objects that it will be referencing during thr course of execution. They can be found in the classes directory. The general format is that Image contains a list of type ImageLayer and each ImageLayer contains a list of type Package. On top of that each of those objects contain an object of type Origins. The Origins object contains a list of type NoticeOrigin which contains a list of type Notice.
+
+A Notice object is where notice messages and the notice levels are recorded. Right now there are 4 notice levels: 'error', 'warning', 'hint' and 'info'. The 'hint' is not so much as to indicate the gravity of the notice but to inform the user on the best way to remove the notice.
+
+## Utilities
+The utility modules are organized in files under specific operations in the utils folder. They are used across the whole project. They should be operational by themselves and can be used independent of the main tern executable. For example, cache.py can implement cache CRUD operations that could be used through some API as well as the executable. Typically, utilities raise errors that other modules may implement in a try-catch. So they can be considered as low-level modules.
+
+## Subroutines
+The subroutines that run some common steps that could be used anywhere in the project are located in common.py. There is also a dockery.py file that contains subroutines specific to Docker containers. There is room for these to move around as the project grows.
+
+Check out [how to navigate the code](./docs/navigating-the-code.md) if you are ready to contribute.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Tern Architecture
 
-You may want to look at the [glossary](./docs/glossary.md) to understand the terms being used.
+You may want to look at the [glossary](./glossary.md) to understand the terms being used.
 
 ## Overall Approach
 The general approach to finding package metadata given some files is to perform static analysis on the files. Tern's approach is more brute force - using the same tools that were used to install a package to retrieve the status of the package. This involves spinning up a container and running shell commands against it. The results of the shell commands are then collated into a nice report showing which container layers brought in what packages. For compliance purposes (as Tern is a compliance tool), shell scripts retrieving package versions, licenses and source urls are used. Tern is also built to be a tool for guidance, and to that effect it is opinionated. For example, if it cannot find information about licenses, it will inform you of this and nudge you to either add information about it or a shell script to retrieve it.
@@ -19,7 +19,7 @@ This is the database where filesystem identifiers can be queried against to retr
 ### The Command Library
 This is a database of shell commands that may be used to create a container's layer filesystem. There are two types of shell commands - one for base images and one for standalone shell commands. The library is split in this way to account for situations where whole root filesystems are imported in order to create a new container.
 
-For example, in [this Dockerfile sample](./samples/debian_vim/Dockerfile), the use of FROM debian:jessie imports the base debian:jessie image from Dockerhub. This image is in turn created with a [Dockerfile](https://github.com/debuerreotype/docker-debian-artifacts/blob/b024a792c752a5c6ccc422152ab0fd7197ae8860/jessie/Dockerfile) that has the FROM scratch directive and adds an entire root filesystem created from an external build an release pipeline not related to Docker. The base library is meant to keep track of such images. On the other hand, the snippets library is used to keep track of standalone shell commands that can be used to install packages, once you hava a base image to work on.
+For example, in [this Dockerfile sample](../samples/debian_vim/Dockerfile), the use of FROM debian:jessie imports the base debian:jessie image from Dockerhub. This image is in turn created with a [Dockerfile](https://github.com/debuerreotype/docker-debian-artifacts/blob/b024a792c752a5c6ccc422152ab0fd7197ae8860/jessie/Dockerfile) that has the FROM scratch directive and adds an entire root filesystem created from an external build an release pipeline not related to Docker. The base library is meant to keep track of such images. On the other hand, the snippets library is used to keep track of standalone shell commands that can be used to install packages, once you hava a base image to work on.
 
 Some acknowledgement should be made here that this is not the only way to create a container. However, it seems to be the most prevalent way and a way that makes sense to most people creating containers and tools like Docker allow for this to be done easily.
 
@@ -37,4 +37,4 @@ The utility modules are organized in files under specific operations in the util
 ## Subroutines
 The subroutines that run some common steps that could be used anywhere in the project are located in common.py. There is also a dockery.py file that contains subroutines specific to Docker containers. There is room for these to move around as the project grows.
 
-Check out [how to navigate the code](./docs/navigating-the-code.md) if you are ready to contribute.
+Check out [how to navigate the code](./navigating-the-code.md) if you are ready to contribute.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,12 @@
+# FAQ (Work in Progress)
+
+## Why Tern?
+Tern was created to help developers meet open source compliance requirements for containers. Open source software compliance is a hard problem in general but it gets harder with containers due to the ability to reuse diff filesystems. How those filesystems were created is still an ad hoc process. If you happen to have an lwn subscription you can read an article about it [here](https://lwn.net/Articles/752982/).
+
+The first step in meeting open source compliance obligations is knowing your container's Bill of Materials or BoM. This knowledge gives you some added benefits like debugging integration and build errors and identifying vulnerable packages in your running containers.
+
+## Why not filesystem scanning?
+Static analysis is a reasonable approach to find software components and there are tools like [clair](https://github.com/coreos/clair) that create a BoM as part of vulnerability scanning. Some things to consider when using static analysis is the number of false positives that are detected, the time it takes to scan numerous files (some of which may not even be needed for an application to work) and the reliance on data that may not be open sourced. Tern is not meant to be a replacement for static analysis but simply a tool that automates some of the methods that developers and sysadmins use anyway.
+
+## Why Python?
+Python is well suited for easy string formatting which is most of the work that Tern does.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,11 @@
+# Glossary of Terms
+
+- Command Library: Tern references a database of shell commands to determine what packages got installed. This is called the "Command Library".
+- Report: the artifact produced after running Tern. This is either a text document or a machine readable format.
+- Image: A container image, typically following the [OCI image specification](https://github.com/opencontainers/image-spec/blob/master/spec.md)
+- Layer: A root filesystem or the difference between a previous filesystem and a new filesystem as created by storage drivers like AUFS or OverlayFS. See the [OCI Image Layer specification](https://github.com/opencontainers/image-spec/blob/master/layer.md) for a general overview of how layer filesystems are created.
+- Package: A software package or library
+- Notice: A record of an incident that Tern came across during execution
+- Notice Origin: The location from which the Notice came. This can be the container or Dockerfile or Command Library or something in the development environment.
+- Cache: A database that associates container layer filesystems with the packages that were installed on them. Currently this is only represented by a yaml file and some CRUD operations against it.
+- Dockerfile: A file containing instructions to the [Docker](https://docs.docker.com/engine/reference/commandline/build/) daemon on how to build a container.

--- a/docs/navigating-the-code.md
+++ b/docs/navigating-the-code.md
@@ -1,0 +1,67 @@
+# Navigating Tern's Code
+
+To help with code navigation, looking up the [glossary](/docs/glossary.md) is useful
+
+Here is a layout of the directory structure:
+
+```
+|--- classes
+|    |--- package.py (Package class)
+|    |--- image_layer.py (ImageLayer class)
+|    |--- image.py (abstract Image class)
+|    |--- docker_image.py (DockerImage class)
+|    |--- command.py (Command class)
+|    |--- notice.py (Notice class)
+|    |--- notice_origin.py (NoticeOrigin class)
+|    └--- origins.py (Origins class)
+|
+|--- command_lib
+|    |--- command_lib.py (operations on the command library)
+|    |--- base.yml (command library for base images)
+|    └--- snippets.yml (command library for code snippets)
+|
+|--- docs (where all the documentation lives)
+|
+|--- report
+|    |--- content.py (content generation)
+|    |--- errors.py (error messages)
+|    |--- formats.py (report formats or string snippets)
+|    └--- report.py (report collation operations)
+|
+|--- samples (sample Dockerfiles)
+|
+|--- scripts (where container or host runnable scripts live)
+|
+|--- tests (unit and functional tests)
+|
+|--- utils
+|    |--- cache.py (cache operations)
+|    |--- constants.py (constants)
+|    |--- container.py (container operations - currently docker related)
+|    |--- dockerfile.py (dockerfile parser)
+|    |--- general.py (general operations)
+|    └--- metadata.py (container image metadata operations)
+|
+|--- cache.yml (container layer cache)
+|
+|--- common.py (common subroutines)
+|
+|--- docker.py (docker related subroutines)
+|
+└--- tern (the main executable)
+```
+
+Some general rules about where the code is located:
+- Utilities used anywhere in the project go in utils
+- Class definitions go in classes. For clarity, the name of the file is also the name of the class but with an underscore separating the words rather than CamelCase
+- Any operation related to look up and operations with the Command Library go in command_lib
+- Any documentation goes in docs.
+- Any operations related to reporting go in report.
+- Any sample Dockerfiles go in samples. The directory structure needs to be such that the Dockerfile exists along with the image context. This means that when you use "docker build" only the Dockerfile gets sent to the docker daemon rather than the whole directory structure. This saves on build time.
+- The scripts directory is not used by the project yet, but there is potential to use it for complicated operations such as extracting source tarballs
+- All unit and functional tests go in tests
+
+Code organization follows these general rules:
+- Each class is in its own file
+- Utils are organized based on what they operate on
+- Subroutines that require the use of modules from all over the project live in high level files like common.py and docker.py 

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -1,31 +1,19 @@
 # Project Road Map
 
-## Guiding Principles
+## 2018
+The end goal for 2018 is to make the project relevant to real world containers and to make it easy to contribute to it. Milestones for the project can be discussed on the community slack channel or the public forum. See the [contributing guide](../CONTRIBUTING.md) for information on how to join the conversation.
 
-* Tern is mean to provide guidance for building more compliant containers by
-  * Analyzing an existing container for packages that are installed
-  * Extracting the sources for packages governed by licenses that require sources to be provided
-  * Rebuilding the container using equivalent packages for which the provenance (exact source code) is known
+## Release 0.1.0
+- Create isolated environments to operate on without using other dependencies
+- Analyze a container image layer by layer
+- Optimize shell script workload for package managers
 
-* The output that Tern creates should not be the source of truth for what is installed in the container nor be used without review. This is because the universe of software installation, package creation and management solutions including dependency management solutions is quite large. There are many different methods of discerning the contents of the container and their provenances but none of them are 100% accurate. In the end, only the person building the container knows for sure what it is meant to contain.
+## Release 0.2.0
+- Work on raw container images along with Dockerfiles
+- Ability to track true base images (FROM scratch in Dockerfiles)
+- Support for images created from multiple imports
+- Support for ADD, COPY and WORKDIR
 
-* Tern is not meant to be the 'silver bullet' for container compliance. Tern cannot tell you whether the packages installed on your container are 'compliant'.It is not a lawyer and is not meant to replace your compliance and/or legal team. It is only meant to automate some of the tasks that you may have to do yourself in order to meet the legal obligations for the software installed.
-
-## Package information extraction
-
-* Integration with a static analysis tool - Research
-* SPDX document output
-* YAML document output - Phase 3
-* Check container against a ruleset - Backlog
-
-## Source Retrieval
-
-* Implementation of sources tarball retrieval - Phase 4
-* Configuration to point to an external repository for scripts - Backlog
-* Configuration to point to an external database - Research
-
-## Reconstruct a compliant image
-
-* Use configured database of known good binaries - Phase 5
-* Use container labeling for metadata like build number and content digest
-* Use container signing
+## Release 0.3.0
+- Hardening with a variety of Dockerfiles
+- Support for multistage build Dockerfiles

--- a/report/report.py
+++ b/report/report.py
@@ -18,6 +18,7 @@ from classes.package import Package
 from command_lib import command_lib
 import common
 import docker
+import sys
 
 '''
 Create a report
@@ -130,6 +131,11 @@ def generate_report(args, *images):
 def execute_dockerfile(args):
     '''Execution path if given a dockerfile'''
     logger.debug('Setting up...')
+    try:
+        container.docker_command(['docker', 'ps'])
+    except subprocess.CalledProcessError as error:
+        logger.error('Docker daemon is not running: {0}'.format(error.output.decode('utf-8')))
+        sys.exit()
     setup(args.dockerfile)
     dockerfile_parse = False
     # try to get Docker base image metadata


### PR DESCRIPTION
This will check whether docker is running or not through the subprocess module. I have used the check_output method which is using "docker ps" command to check whether docker daemon is running or not. If docker is not running then subprocess module raises the ProcessError exception which is being used to raise the customized message on the console and gracefully exit the script.
Resolves: #28

Signed-off-by: Raman Balyan <raman.balyan@gmail.com>