### PR TITLE
Gracefully exit if the docker daemon is not running

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,24 @@ If you would like to chat live, you can join the [slack channel](https://vmwarec
 - [Architecture](/docs/architecture.md)
 - [Navigating the Code](/docs/navigating-the-code.md)
 
+## Coding Style
+
+Tern follows general [PEP8](https://www.python.org/dev/peps/pep-0008/) style guidelines. Apart from that, these specific rules apply:
+- Indents for .py files are 4 spaces long
+- Indents for .yml files are 2 spaces long
+- Modules are listed as external dependencies, followed by a space, followed by internal dependencies, listed individually and in alphabetical order. For example:
+```
+# external dependencies not part of Tern
+# possibly part of the python package or installed via pip
+import os
+import sys
+
+# internal dependencies that are part of Tern
+import common
+import docker
+```
+- Minimize [cyclomatic complexity](https://en.wikipedia.org/wiki/Cyclomatic_complexity). Most python style checkers also come with McCabe complexity checkers. A good rule of thumb is to limit the number of if-then-else statements to 3 and return once in a module.
+
 ## An overview of the contribution lifecycle
 
 Once you decide that you would like to play around with the project

--- a/report/report.py
+++ b/report/report.py
@@ -5,6 +5,7 @@ SPDX-License-Identifier: BSD-2-Clause
 
 import logging
 import subprocess
+import sys
 
 from report import content
 from utils import container
@@ -18,6 +19,7 @@ from classes.package import Package
 from command_lib import command_lib
 import common
 import docker
+
 
 '''
 Create a report
@@ -130,6 +132,12 @@ def generate_report(args, *images):
 def execute_dockerfile(args):
     '''Execution path if given a dockerfile'''
     logger.debug('Setting up...')
+    try:
+        container.docker_command(['docker', 'ps'])
+    except subprocess.CalledProcessError as error:
+        logger.error('Docker daemon is not running: {0}'.format(error.output.decode('utf-8')))
+        sys.exit()
+
     setup(args.dockerfile)
     dockerfile_parse = False
     # try to get Docker base image metadata


### PR DESCRIPTION
This will check whether docker is running or not through the subprocess module. I have used the check_output method which is using "docker ps" command to check whether docker daemon is running or not. If docker is not running then subprocess module raises the ProcessError exception which is being used to raise the customized message on the console and gracefully exit the script.

Resolves: #28

Signed-off-by: Raman Balyan <raman.balyan@gmail.com>