### PR TITLE
Gracefully exit if the docker daemon is not running

### DIFF
--- a/report/report.py
+++ b/report/report.py
@@ -5,6 +5,7 @@ SPDX-License-Identifier: BSD-2-Clause
 
 import logging
 import subprocess
+import sys
 
 from report import content
 from utils import container
@@ -130,6 +131,12 @@ def generate_report(args, *images):
 def execute_dockerfile(args):
     '''Execution path if given a dockerfile'''
     logger.debug('Setting up...')
+    try:
+        container.docker_command(['docker', 'ps'])
+    except subprocess.CalledProcessError as error:
+        logger.error('Docker daemon is not running: {0}'.format(error.output.decode('utf-8')))
+        sys.exit()
+
     setup(args.dockerfile)
     dockerfile_parse = False
     # try to get Docker base image metadata


### PR DESCRIPTION
This will check whether docker is running or not through the docker_command present in container.py file. I have used the "docker ps" command to check whether docker daemon is running or not. If docker is not running then subprocess module raises the ProcessError exception which is being used to raise the customized message on the console and gracefully exit the script.

Resolves: #28

Signed-off-by: Raman Balyan <raman.balyan@gmail.com>