### PR TITLE
Random names for the Container, Image, and Tag are created on start-up

### DIFF
--- a/report/report.py
+++ b/report/report.py
@@ -15,6 +15,7 @@ from report import formats
 from utils import container
 from utils import constants
 from utils import cache
+from utils import general
 from utils import rootfs
 from classes.docker_image import DockerImage
 from classes.image import Image
@@ -41,6 +42,8 @@ def write_report(report):
 
 def setup(dockerfile=None, image_tag_string=None):
     '''Any initial setup'''
+    # generate random names for image, container, and tag
+    general.initialize_names()
     # load the cache
     cache.load()
     # load dockerfile if present

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -11,11 +11,11 @@ Constants
 # this is relative to where the tern executable is
 temp_folder = 'temp'
 # built image name
-image = 'testimage'
+image = 'ternimage'
 # built image tag
-tag = 'testtag'
+tag = 'terntag'
 # running container name
-container = 'testcontainer'
+container = 'terncontainer'
 # logger name
 logger_name = 'ternlog'
 # logfile

--- a/utils/general.py
+++ b/utils/general.py
@@ -3,10 +3,12 @@ Copyright (c) 2017 VMware, Inc. All Rights Reserved.
 SPDX-License-Identifier: BSD-2-Clause
 '''
 import os
+import random
 import re
 
 from contextlib import contextmanager
 
+from . import constants
 
 # from https://stackoverflow.com/questions/6194499/pushd-through-os-system
 @contextmanager
@@ -15,6 +17,13 @@ def pushd(path):
     os.chdir(path)
     yield
     os.chdir(curr_path)
+
+
+def initialize_names():
+   randint = random.randint(10000,99999)
+   constants.image = constants.image + "_" + str(randint)
+   constants.tag = constants.tag + "_" + str(randint)
+   constants.container = constants.container + "_" + str(randint)
 
 
 def parse_command(command):


### PR DESCRIPTION
When report.setup gets called, general.initialize_names is called to
create random names for Container, Image, and Tag. This function will
append a 5 digit random integer to the end of the Container, Image, or
Tag name.

Resolves: #74 

Signed-off-by: John Miller <jmille40@gmu.edu>