### PR TITLE
Add alternative to using the package manager to find dependencies for a package

### DIFF
--- a/command_lib/command_lib.py
+++ b/command_lib/command_lib.py
@@ -113,20 +113,10 @@ def get_image_shell(base_image_listing):
     return shell, msg
 
 
-def get_package_listing(command_name, package_name=''):
+def get_package_listing(command_name):
     '''Given a command name, return the package listing from the snippet
-    library.
-    1. Get the listing for the command name
-    2. Check if the 'packages' value is a string, if it is return the string
-    3. If not, check if there is a package name in the package list or
-    if the default method that should be used'''
-    command_listing = get_command_listing(command_name)
-    if not package_name:
-        pkg_listing = command_listing['packages']
-    else:
-        pkg_listing = check_for_unique_package(
-            command_listing['packages'], package_name)
-    return pkg_listing
+    library.'''
+    return get_command_listing(command_name)['packages']
 
 
 def set_command_attrs(command_obj):

--- a/command_lib/command_lib.py
+++ b/command_lib/command_lib.py
@@ -115,11 +115,17 @@ def get_image_shell(base_image_listing):
 
 def get_package_listing(command_name, package_name):
     '''Given a command name, return the package listing from the snippet
-    library. First get the listing for the command name and then check if
-    there is a package name in the package list or the default'''
+    library.
+    1. Get the listing for the command name
+    2. Check if the 'packages' value is a string, if it is return the string
+    3. If not, check if there is a package name in the package list or
+    if the default method that should be used'''
     command_listing = get_command_listing(command_name)
-    pkg_listing = check_for_unique_package(
-        command_listing['packages'], package_name)
+    if type(command_listing['packages']) is str:
+        pkg_listing = command_listing['packages']
+    else:
+        pkg_listing = check_for_unique_package(
+            command_listing['packages'], package_name)
     return pkg_listing
 
 
@@ -132,13 +138,13 @@ def set_command_attrs(command_obj):
         # the command is in the library
         if 'install' in command_listing.keys():
             # try to move install to a subcommand
-            if command_obj.reassign_word(
-                command_listing['install'], 'subcommand'):
+            if command_obj.reassign_word(command_listing['install'],
+                                         'subcommand'):
                 command_obj.set_install()
         if 'remove' in command_listing.keys():
             # try to move remove to a subcommand
-            if command_obj.reassign_word(
-                command_listing['remove'], 'subcommand'):
+            if command_obj.reassign_word(command_listing['remove'],
+                                         'subcommand'):
                 command_obj.set_remove()
         if 'ignore' in command_listing.keys():
             # check if any of the words in the ignore list are in
@@ -236,7 +242,7 @@ def get_pkg_attr_list(shell, attr_dict, package_name='', chroot=True,
                     except subprocess.CalledProcessError as error:
                         error_msgs = error_msgs + error.output
                 else:
-                # if we need to run in a container
+                    # if we need to run in a container
                     try:
                         result = invoke_in_container(
                             snippet_list, shell, package=package_name,

--- a/command_lib/command_lib.py
+++ b/command_lib/command_lib.py
@@ -113,7 +113,7 @@ def get_image_shell(base_image_listing):
     return shell, msg
 
 
-def get_package_listing(command_name, package_name):
+def get_package_listing(command_name, package_name=''):
     '''Given a command name, return the package listing from the snippet
     library.
     1. Get the listing for the command name
@@ -121,7 +121,7 @@ def get_package_listing(command_name, package_name):
     3. If not, check if there is a package name in the package list or
     if the default method that should be used'''
     command_listing = get_command_listing(command_name)
-    if type(command_listing['packages']) is str:
+    if not package_name:
         pkg_listing = command_listing['packages']
     else:
         pkg_listing = check_for_unique_package(

--- a/command_lib/snippets.yml
+++ b/command_lib/snippets.yml
@@ -51,31 +51,9 @@ tyum:
   remove: 'remove'
   ignore:
     - 'check-update'
-  packages:
-    - name: default
-      version:
-        invoke:
-          1:
-            container:
-              - 'list=`tdnf list installed {package}`'
-              - 'c=0; for l in $list; do if [ $c == 1 ]; then echo $l; fi; c=$(((c+1)%3)); done;'
-      license:
-        invoke:
-          1:
-            container:
-              - 'tdnf info {package} | head -10 | tail -1 | cut -f2 -d":" | xargs'
-      src_url:
-        invoke:
-          1:
-            container:
-              - 'tdnf info {package} | head -9 | tail -1 | cut -f2-3 -d":" | xargs'
-      deps:
-        invoke:
-          1:
-            container:
-              - 'list=`rpm -qR {package} | cut -f1 -d" "`'
-              - 'for l in $list; do rpm -qa --queryformat "%{NAME}\n" $l; done;'
-        delimiter: "\n"
+    - 'clean'
+  packages: 'tdnf'
+
 apk:
   install: 'add'
   remove: 'del'

--- a/common.py
+++ b/common.py
@@ -269,48 +269,42 @@ def filter_install_commands(shell_command_line):
     return filter2, report
 
 
-def add_diff_packages(diff_layer, command_line, shell):
-    '''Given a layer object, command line string that created it, and the
+def add_snippet_packages(image_layer, command, shell):
+    '''Given an image layer object, a command object, and the
     shell used to invoke commands, add package metadata to the layer object
-        1. Parse the command line to get individual install commands
-        2. For each command get the packages installed
+    We assume the filesystem is already mounted and ready
+        1. Get the packages installed by the command
         3. For each package get the dependencies
         4. For each unique package name, find the metadata and add to the
         layer'''
-    origin_layer = 'Layer: ' + diff_layer.fs_hash[:10]
-    # parse all installed commands
-    cmd_list, msg = filter_install_commands(command_line)
-    if msg:
-        diff_layer.origins.add_notice_to_origins(
-            origin_layer, Notice(msg, 'warning'))
-    # find packages for each command
-    for command in cmd_list:
-        cmd_msg = formats.invoke_for_snippets + '\n' + \
-            content.print_package_invoke(command.name)
-        diff_layer.origins.add_notice_to_origins(origin_layer, Notice(
-            cmd_msg, 'info'))
-        pkg_list = get_installed_package_names(command)
-        # collect all the dependencies for each package name
-        all_pkgs = []
-        for pkg_name in pkg_list:
-            pkg_listing = command_lib.get_package_listing(
-                command.name, pkg_name)
-            deps, deps_msg = get_package_dependencies(
-                pkg_listing, pkg_name, shell)
-            if deps_msg:
-                logger.warning(deps_msg)
-                diff_layer.origins.add_notice_to_origins(
-                    origin_layer, Notice(deps_msg, 'error'))
-            all_pkgs.append(pkg_name)
-            all_pkgs.extend(deps)
-        unique_pkgs = list(set(all_pkgs))
-        # get package metadata for each package name
-        for pkg_name in unique_pkgs:
-            pkg = Package(pkg_name)
-            pkg_listing = command_lib.get_package_listing(
-                command.name, pkg_name)
-            fill_package_metadata(pkg, pkg_listing, shell)
-            diff_layer.add_package(pkg)
+    # set up a notice origin for the layer
+    origin_layer = 'Layer: ' + image_layer.fs_hash[:10]
+    # find packages for the command
+    cmd_msg = formats.invoke_for_snippets + '\n' + \
+        content.print_package_invoke(command.name)
+    image_layer.origins.add_notice_to_origins(origin_layer, Notice(
+        cmd_msg, 'info'))
+    pkg_list = get_installed_package_names(command)
+    # collect all the dependencies for each package name
+    all_pkgs = []
+    for pkg_name in pkg_list:
+        pkg_listing = command_lib.get_package_listing(
+            command.name, pkg_name)
+        deps, deps_msg = get_package_dependencies(
+            pkg_listing, pkg_name, shell)
+        if deps_msg:
+            logger.warning(deps_msg)
+            image_layer.origins.add_notice_to_origins(
+                origin_layer, Notice(deps_msg, 'error'))
+        all_pkgs.append(pkg_name)
+        all_pkgs.extend(deps)
+    unique_pkgs = list(set(all_pkgs))
+    # get package metadata for each package name
+    for pkg_name in unique_pkgs:
+        pkg = Package(pkg_name)
+        pkg_listing = command_lib.get_package_listing(command.name, pkg_name)
+        fill_package_metadata(pkg, pkg_listing, shell)
+        image_layer.add_package(pkg)
 
 
 def update_master_list(master_list, layer_obj):

--- a/common.py
+++ b/common.py
@@ -269,10 +269,10 @@ def filter_install_commands(shell_command_line):
     return filter2, report
 
 
-def add_snippet_packages(image_layer, command, shell):
-    '''Given an image layer object, a command object, and the
-    shell used to invoke commands, add package metadata to the layer object
-    We assume the filesystem is already mounted and ready
+def add_snippet_packages(image_layer, command, pkg_listing, shell):
+    '''Given an image layer object, a command object, the package listing
+    and the shell used to invoke commands, add package metadata to the layer
+    object. We assume the filesystem is already mounted and ready
         1. Get the packages installed by the command
         3. For each package get the dependencies
         4. For each unique package name, find the metadata and add to the
@@ -288,10 +288,10 @@ def add_snippet_packages(image_layer, command, shell):
     # collect all the dependencies for each package name
     all_pkgs = []
     for pkg_name in pkg_list:
-        pkg_listing = command_lib.get_package_listing(
-            command.name, pkg_name)
+        pkg_invoke = command_lib.check_for_unique_package(
+            pkg_listing, pkg_name)
         deps, deps_msg = get_package_dependencies(
-            pkg_listing, pkg_name, shell)
+            pkg_invoke, pkg_name, shell)
         if deps_msg:
             logger.warning(deps_msg)
             image_layer.origins.add_notice_to_origins(
@@ -302,8 +302,7 @@ def add_snippet_packages(image_layer, command, shell):
     # get package metadata for each package name
     for pkg_name in unique_pkgs:
         pkg = Package(pkg_name)
-        pkg_listing = command_lib.get_package_listing(command.name, pkg_name)
-        fill_package_metadata(pkg, pkg_listing, shell)
+        fill_package_metadata(pkg, pkg_invoke, shell)
         image_layer.add_package(pkg)
 
 

--- a/report/errors.py
+++ b/report/errors.py
@@ -9,9 +9,9 @@ Error messages
 
 unrecognized_base = '''Unable to determine the base OS of the image ''' \
     '''{image_name}:{image_tag}\n'''
-no_packages = '''Unable to recover packages for layer {layer_id}. Consider ''' \
-    '''either entering them manually or create a bash script to retrieve ''' \
-    '''the package in the command library.\n'''
+no_packages = '''Unable to recover packages for layer {layer_id}. ''' \
+    '''Consider either entering them manually or create a bash script to ''' \
+    '''retrieve the package in the command library.\n'''
 no_version = '''No version for package {package_name}. Consider either ''' \
     '''entering the version manually or creating a script to retrieve ''' \
     '''it in the command library\n'''
@@ -47,6 +47,8 @@ incomplete_command_lib_listing = '''The command library has an incomplete ''' \
 no_shell_listing = '''There is no listing for 'shell' under the base ''' \
     '''listing for {binary}. Using default shell: ''' \
     '''{default_shell}\n'''
+unknown_content = '''Unknown content included in layer {files}. Please ''' \
+    '''analyze these files separately\n'''
 
 # Dockerfile specific errors
 dockerfile_no_tag = '''The Dockerfile provided has no tag in the line ''' \

--- a/report/report.py
+++ b/report/report.py
@@ -139,13 +139,27 @@ def analyze_docker_image(image_obj, dockerfile=False):
     shell = ''
     # set up empty master list of package names
     master_list = []
-    # find the shell by mounting the base layer
+    # find the binary by mounting the base layer
     target = rootfs.mount_base_layer(image_obj.layers[0].tar_file)
     binary = common.get_base_bin(image_obj.layers[0])
+    # set up a notice origin referring to the base command library listing
+    origin_command_lib = formats.invoking_base_commands
     # find the shell to invoke commands in
-    shell, _ = command_lib.get_image_shell(
+    shell, msg = command_lib.get_image_shell(
         command_lib.get_base_listing(binary))
     if not shell:
+        # add a warning notice for no shell in the command library
+        logger.warning('No shell listing in command library. '
+                       'Using default shell')
+        no_shell_message = errors.no_shell_listing.format(
+            binary, default_shell=constants.shell)
+        image_obj.layers[0].origins.add_notice_to_origins(
+            origin_command_lib, Notice(no_shell_message, 'warning'))
+        # add a hint notice to add the shell to the command library
+        add_shell_message = errors.no_listing_for_base_key.format(
+            listing_key='shell')
+        image_obj.layers[0].origins.add_notice_origins(
+            origin_command_lib, Notice(add_shell_message, 'hint'))
         shell = constants.shell
     # only extract packages if there is a known binary and the layer is not
     # cached
@@ -153,7 +167,7 @@ def analyze_docker_image(image_obj, dockerfile=False):
         if not common.load_from_cache(image_obj.layers[0]):
             # get the packages of the first layer
             rootfs.prep_rootfs(target)
-            common.add_base_packages(image_obj.layers[0], binary)
+            common.add_base_packages(image_obj.layers[0], binary, shell)
             # unmount proc, sys and dev
             rootfs.undo_mount()
     else:

--- a/utils/dockerfile.py
+++ b/utils/dockerfile.py
@@ -1,5 +1,5 @@
 '''
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+Copyright (c) 2017-2018 VMware, Inc. All Rights Reserved.
 SPDX-License-Identifier: BSD-2-Clause
 '''
 import re
@@ -9,6 +9,7 @@ Dockerfile parser and information retrieval
 
 directives = ['FROM',
               'ARG',
+              'ADD',
               'RUN',
               'ENV',
               'COPY',

--- a/utils/general.py
+++ b/utils/general.py
@@ -1,5 +1,5 @@
 '''
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+Copyright (c) 2017-2018 VMware, Inc. All Rights Reserved.
 SPDX-License-Identifier: BSD-2-Clause
 '''
 import os
@@ -9,6 +9,7 @@ import re
 from contextlib import contextmanager
 
 from . import constants
+
 
 # from https://stackoverflow.com/questions/6194499/pushd-through-os-system
 @contextmanager
@@ -20,10 +21,10 @@ def pushd(path):
 
 
 def initialize_names():
-   randint = random.randint(10000,99999)
-   constants.image = constants.image + "_" + str(randint)
-   constants.tag = constants.tag + "_" + str(randint)
-   constants.container = constants.container + "_" + str(randint)
+    randint = random.randint(10000, 99999)
+    constants.image = constants.image + "_" + str(randint)
+    constants.tag = constants.tag + "_" + str(randint)
+    constants.container = constants.container + "_" + str(randint)
 
 
 def parse_command(command):
@@ -51,19 +52,20 @@ def parse_command(command):
     command_dict = {}
     command_tokens = command.split(' ')
     # first token is the command name
-    command_dict.update({'name': command_tokens.pop(0)})
+    command_dict.update({'name': command_tokens.pop(0).strip()})
     # find options in the rest of the list
     while command_tokens:
         if options.match(command_tokens[0]):
-            option_flag = command_tokens.pop(0)
+            option_flag = command_tokens.pop(0).strip()
             # we have to check if this is the end of the command
-            if len(command_tokens) > 0 and not options.match(command_tokens[0]):
-                option_arg = command_tokens[0]
+            if len(command_tokens) > 0 \
+                    and not options.match(command_tokens[0]):
+                option_arg = command_tokens[0].strip()
             else:
                 option_arg = ''
             option_list.append((option_flag, option_arg))
         else:
-            word_list.append(command_tokens.pop(0))
+            word_list.append(command_tokens.pop(0).strip())
     # now we have options and the remainder words
     command_dict.update({'options': option_list,
                          'words': word_list})


### PR DESCRIPTION
Fixes #54 

Sometimes, the package manager for a container OS either cannot find a package's dependencies (like photon2) or they interpret dependencies at the file level (like apk). In this case, we revert to listing the packages installed again and find the difference between the packages installed in the previous layers and the ones installed in the current layer.
Eg:
layer 0: pkg1, pkg2, pkg3
layer 0 + layer 1: pkg1, pkg2, pkg3, pkg4, pkg5
packages in layer 1 only: pkg4, pkg5

Changes:
1. In the snippet.yml listing, for a command used to create a layer, if the 'packages' listing is a string, then use the listing in base.yml for that string.
2. In the docker image analysis, if the package listing is a string then use the baseOS binary to get the list of packages installed. If not then use the snippets invoke methods