### PR TITLE
Added Deep Comparison to Package Object

### DIFF
--- a/classes/package.py
+++ b/classes/package.py
@@ -16,7 +16,9 @@ class Package(object):
         origins: a list of NoticeOrigin objects
 
     methods:
-        to_dict: returns a dict representation of the instance'''
+        to_dict: returns a dict representation of the instance
+        fill: instantiates a package object given a dict representation.
+        is_equal: compares two package objects.'''
     def __init__(self, name):
         self.__name = name
         self.__version = ''
@@ -82,3 +84,15 @@ class Package(object):
         else:
             success = False
         return success
+
+    def is_equal(self, other):
+        '''This method performs a deep comparison between two objects by
+        iterating over the dictionary for each object returned by to_dict
+        and comparing the vales for each key in both. This function will only
+        return true if every key value pair matches between the two
+        dictionaries.'''
+        other_pkg_dict = other.to_dict()
+        for key, value in self.to_dict().items():
+            if value != other_pkg_dict[key]:
+                return False
+        return True

--- a/tests/test_class_package.py
+++ b/tests/test_class_package.py
@@ -6,7 +6,6 @@ SPDX-License-Identifier: BSD-2-Clause
 import unittest
 
 from classes.package import Package
-from classes.notice import Notice
 
 
 class TestClassPackage(unittest.TestCase):
@@ -22,7 +21,6 @@ class TestClassPackage(unittest.TestCase):
         self.assertEqual(self.package.version, '')
         self.assertFalse(self.package.src_url)
         self.assertFalse(self.package.license)
-        self.assertFalse(self.package.notices)
 
     def testSetters(self):
         self.assertRaises(AttributeError, setattr, self.package, 'name', 'y')
@@ -42,15 +40,6 @@ class TestClassPackage(unittest.TestCase):
         self.assertEqual(self.package.license, 'Apache 2.0')
         self.assertEqual(self.package.src_url, 'github.com')
 
-    def testAddNotice(self):
-        n = Notice()
-        n.origin = 'FROM'
-        n.message = 'no image'
-        n.level = 'error'
-        self.package.add_notice(n)
-        self.assertEqual(len(self.package.notices), 1)
-        self.assertEqual(self.package.notices[0].origin, 'FROM')
-
     def testToDict(self):
         self.package.version = '1.0'
         self.package.license = 'Apache 2.0'
@@ -60,6 +49,18 @@ class TestClassPackage(unittest.TestCase):
         self.assertEqual(a_dict['version'], '1.0')
         self.assertEqual(a_dict['license'], 'Apache 2.0')
         self.assertEqual(a_dict['src_url'], 'github.com')
+
+    def testIsEqual(self):
+        p = Package('x')
+        p.license = 'TestLicense'
+        p.version = '1.0'
+        p.src_url = 'TestUrl'
+        self.package.license = 'TestLicense'
+        self.package.version = '2.0'
+        self.package.src_url = 'TestUrl'
+        self.assertFalse(self.package.is_equal(p))
+        p.version = '2.0'
+        self.assertTrue(self.package.is_equal(p))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Used Package.To_Dict to compare two objects so that if
new attributes are added to the Package object, this code
will not be impacted. This commit also added relevant
tests for the function and removed a Add_Notice tests
which no longer exists in the Package object.

Resolves: #78
Signed-off-by: John Miller <jmille40@gmu.edu>