### PR TITLE
Compare package objects rather than package names

### DIFF
--- a/common.py
+++ b/common.py
@@ -35,8 +35,8 @@ def get_shell_commands(shell_command_line):
 def load_from_cache(layer, redo=False):
     '''Given a layer object, check against cache to see if that layer id exists
     if yes then get the package list and load it in the layer and return true.
-    If it doesn't exist return false. Default operation is to not redo the cache.
-    Add notices to the layer's origins matching the origin_str'''
+    If it doesn't exist return false. Default operation is to not redo the
+    cache. Add notices to the layer's origins matching the origin_str'''
     loaded = False
     origin_layer = 'Layer: ' + layer.fs_hash[:10]
     if not layer.packages and not redo:
@@ -305,15 +305,26 @@ def add_snippet_packages(image_layer, command, pkg_listing, shell):
 
 
 def update_master_list(master_list, layer_obj):
-    '''A general utility to update a master list of package names and clean
-    out a layer's list of package objects
-    Given a master list of package names and a layer object containing a list
-    of package objects, append to the master list all the package names that
-    are not in the master list and remove the duplicate packages from the
+    '''Given a master list of package objects and a layer object containing a
+    list of package objects, append to the master list all the package objects
+    that are not in the master list and remove the duplicate packages from the
     layer object'''
-    layer_packages = layer_obj.get_package_names()
-    keep_list = list(set(layer_packages) - set(master_list))
-    remove_list = list(set(layer_packages) - set(keep_list))
-    master_list.extend(keep_list)
-    for pkg in remove_list:
-        layer_obj.remove_package(pkg)
+    # temporary placement of package objects
+    unique = []
+    for i in range(len(layer_obj.packages)):
+        item = layer_obj.packages.pop(0)
+        # check for whether the package exists on the master list
+        exists = False
+        for pkg in master_list:
+            if item.is_equal(pkg):
+                exists = True
+                break
+        if not exists:
+            unique.append(item)
+    # add all the unique packages to the master list
+    for u in unique:
+        master_list.append(u)
+    # empty the unique packages back into the layer object
+    while unique:
+        layer_obj.packages.append(unique.pop(0))
+    del unique

--- a/report/report.py
+++ b/report/report.py
@@ -165,7 +165,7 @@ def analyze_docker_image(image_obj, redo=False, dockerfile=False):
     # add notices for each layer if it is imported
     image_setup(image_obj)
     shell = ''
-    # set up empty master list of package names
+    # set up empty master list of packages
     master_list = []
     # find the binary by mounting the base layer
     target = rootfs.mount_base_layer(image_obj.layers[0].tar_file)
@@ -212,8 +212,7 @@ def analyze_docker_image(image_obj, redo=False, dockerfile=False):
     # unmount the first layer
     rootfs.unmount_rootfs()
     # populate the master list with all packages found in the first layer
-    # can't use assignment as that will just point to the image object's layer
-    for p in image_obj.layers[0].get_package_names():
+    for p in image_obj.layers[0].packages:
         master_list.append(p)
     # get packages for subsequent layers
     curr_layer = 1


### PR DESCRIPTION
If the base OS of a container came with one version of a package,
and an update command in the next layer updates the version to a
newer version of the package, both versions get distributed in
the container image. Comparing using just the package names will
not pick up the update. Compare the whole package rather than
just the package name using the is_equal method in the Package
class.

- Populate the master list with packages rather than just package
names.
- Redo update_master_list implementation to compare package objects
in the master list to the package objects in the given layer object.
Use a temporary list to keep all the unique package objects, append
them to the master list and then pop them out into the layer list.
- Update the comments to reflect this change.
- Small PEP8 error (line too long) in load_from_cache function.

Resolves #77

Signed-off-by: Nisha K <nishak@vmware.com>