### PR TITLE
Convert Docker CLI calls to Docker API calls

### DIFF
--- a/report/report.py
+++ b/report/report.py
@@ -3,6 +3,7 @@ Copyright (c) 2017-2018 VMware, Inc. All Rights Reserved.
 SPDX-License-Identifier: BSD-2-Clause
 '''
 
+import docker
 import logging
 import os
 import shutil
@@ -317,8 +318,8 @@ def generate_yaml(images):
 def check_docker_daemon():
     '''Check if the Docker daemon is running. If not, exit gracefully'''
     try:
-        container.docker_command(['docker', 'ps'])
-    except subprocess.CalledProcessError as error:
+        docker.from_env()
+    except IOError as error:
         logger.error('Docker daemon is not running: {0}'.format(
             error.output.decode('utf-8')))
         sys.exit()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,10 @@
-PyYAML==3.12
+certifi==2018.11.29
+chardet==3.0.4
+docker==3.7.0
+docker-pycreds==0.4.0
+idna==2.8
+PyYAML==3.13
+requests==2.21.0
+six==1.12.0
+urllib3==1.24.1
+websocket-client==0.54.0

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -10,6 +10,8 @@ Constants
 # temporary folder for extracting container image
 # this is relative to where the tern executable is
 temp_folder = 'temp'
+# temporary tar file
+temp_tarfile = 'temp.tar'
 # built image name
 image = 'ternimage'
 # built image tag


### PR DESCRIPTION
Replace all subprocess calls to the Docker CLI with Docker's
python API calls. This required several major changes:

- New dependencies added to requirements.txt
docker -> certifi, chardet, docker-pycreds, idna, requests, six,
urllib3, websocket-client
- Docker's API call for 'save' returned a generator rather than a
byte stream, so functionality was changed to write the tar stream
to a temporary file, then read from the file to extract the tar
to a temporary folder, and finally delete the temporary file. This
change was needed anyway as the tool would often run out of memory
for big container images.
- Added temporary tar file name to constants
- Removed all docker CLI commands
- Removed unused modules
- Refactored check for running docker daemon

Resolves #137

Signed-off-by: Nisha K <nishak@vmware.com>