### PR TITLE
Pull docker image if not on disk

### DIFF
--- a/report/errors.py
+++ b/report/errors.py
@@ -69,8 +69,8 @@ dockerfile_fallback = '''Falling back on parsing the Dockerfile for ''' \
     '''package information\n'''
 no_running_docker_container = '''Cannot invoke commands in a container '''\
     '''as there is no running container.\n'''
-cannot_find_image = '''Cannot find image {imagetag}. Please provide image '''\
-    '''and tag that was pulled.\n'''
+cannot_find_image = '''Cannot find image {imagetag} locally or from remote '''\
+    '''registry.\n'''
 
 # not error messages but stuff for the logger
 no_base_image = '''Base image is FROM scratch. Skipping to build'''

--- a/utils/container.py
+++ b/utils/container.py
@@ -63,8 +63,11 @@ def check_container():
 
 def check_image(image_tag_string):
     '''Check if image exists'''
+    logger.debug("Checking if image {} is available on disk...".format(
+        image_tag_string))
     try:
         client.images.get(image_tag_string)
+        logger.debug("Image {} found".format(image_tag_string))
         return True
     except docker.errors.ImageNotFound:
         return False
@@ -72,8 +75,10 @@ def check_image(image_tag_string):
 
 def pull_image(image_tag_string):
     '''Try to pull an image from Dockerhub'''
+    logger.debug("Attempting to pull image {}".format(image_tag_string))
     try:
         client.images.pull(image_tag_string)
+        logger.debug("Image {} downloaded".format(image_tag_string))
         return True
     except docker.errors.ImageNotFound:
         logger.warning("No such image: {}".format(image_tag_string))


### PR DESCRIPTION
This change is useful when tern is running in a container on some
newly provisioned VM or machine.

- Added some logging within check_image and pull_image utility
functions
- Modified docker image setup to pull an image if it doesn't exist
on disk
- Modified analysis of base image to do the same check
- Modified error message to reflect the change

Resolves #151

Signed-off-by: Nisha K <nishak@vmware.com>