### PR TITLE
Call fs_hash.sh tool using root_command wrapper

### DIFF
--- a/utils/rootfs.py
+++ b/utils/rootfs.py
@@ -172,8 +172,8 @@ def calc_fs_hash(fs_path):
     directory.
     Note that this file will be deleted if the -k flag is not given'''
     try:
-        hash_contents = subprocess.check_output(
-            ['sudo', './tools/fs_hash.sh', os.path.abspath(fs_path)])
+        hash_contents = root_command(
+            ['./tools/fs_hash.sh'], os.path.abspath(fs_path))
         file_name = hashlib.sha256(hash_contents).hexdigest()
         # write file to an appropriate location
         hash_file = os.path.join(os.path.dirname(fs_path), file_name) + '.txt'


### PR DESCRIPTION
Currently, this hashing function needs to run as root. Sudo was
hard coded into the subprocess call, which causes it to fail if the
user running fs_hash was root, as is the case with Docker containers

Fixes #153

Signed-off-by: Nisha K <nishak@vmware.com>