### PR TITLE
Remove logging's console StreamHandler

### DIFF
--- a/tern
+++ b/tern
@@ -20,17 +20,13 @@ Tern executable
 logger = logging.getLogger(constants.logger_name)
 logger.setLevel(logging.DEBUG)
 
-console = logging.StreamHandler()
-console.setLevel(logging.DEBUG)
 formatter = logging.Formatter(
     '%(asctime)s - %(levelname)s - %(module)s - %(message)s')
-console.setFormatter(formatter)
 
 log_handler = logging.FileHandler(constants.logfile, mode='w')
 log_handler.setLevel(logging.DEBUG)
 log_handler.setFormatter(formatter)
 
-logger.addHandler(console)
 logger.addHandler(log_handler)
 
 


### PR DESCRIPTION
To allow for tern to act as a web service, the debug messages
should not be streamed to stdout. For console use, one can run
tail -f tern.log to get the same real time observability.

Removed logging.StreamHandler object along with setting level and
formatter.

Resolves #155

Signed-off-by: Nisha K <nishak@vmware.com>