### PR TITLE
Added -b option to work with bind mount directory

### DIFF
--- a/tern
+++ b/tern
@@ -71,12 +71,16 @@ if __name__ == '__main__':
     information about packages that are installed in a container image.
     Learn more at https://github.com/vmware/tern''')
     parser.add_argument('-l', '--log-stream', action='store_true',
-                        help="Stream logs to the console.\n"
+                        help="Stream logs to the console;"
                         "Useful when running in a shell")
     parser.add_argument('-c', '--clear-cache', action='store_true',
                         help="Clear the cache before running")
     parser.add_argument('-k', '--keep-working-dir', action='store_true',
-                        help="Keep the working directory after execution")
+                        help="Keep the working directory after execution;"
+                        "Useful when debugging container images")
+    parser.add_argument('-b', '--bind-mount', action='store_true',
+                        help="Treat working directory as a bind mount;"
+                        "Needed when running from within a container")
     parser.add_argument('-r', '--redo', action='store_true',
                         help="Repopulate the cache for found layers")
     subparsers = parser.add_subparsers(help='Subcommands')


### PR DESCRIPTION
In order to make tern work from within a running docker container,
it needs access to a directory that is bind mounted to the container.
The reason for this is because tern uses overlay2 to examine each layer
in context with the previous layers of the container.

A docker container is built with a working directory called 'temp',
When running this container using docker run, a host directory is
bind mounted using --mount type=bind,source=<host directory>,
target=/temp. In this scenario, it isn't possible to do a complete
clean of the working directory. So we add an option -b to tell the
script that we are bind mounting a working directory.

If -b is true, then only the contents of temp will be deleted, leaving
the high level directory intact. If -b is false, temp will also be
deleted. Note that if -k is set, regardless of whether -b is set or
not, i.e., whether we're working within a running container or not,
the temp directory with all of its contents remain intact

- Added CLI option -b, --bind-mount to use a bind mounted directory
as the working directory
- Updated punctuation in CLI help
- Added a bind_mount arg to clean_working_dir function. If true, then
the contents of the temp_folder will be deleted without deleting the
temp_folder
- Updated execute_dockerfile and execute_docker_image with using
clean_working_dir with the bind_mount arg

Resolves #164

Signed-off-by: Nisha K <nishak@vmware.com>