### PR TITLE
Report out to stdout by default

### DIFF
--- a/tern
+++ b/tern
@@ -96,10 +96,14 @@ if __name__ == '__main__':
     parser_report.add_argument('-s', '--summary', action='store_true',
                                help="Summarize the report as a list of"
                                " packages with associated information")
-    parser_report.add_argument('-Y', '--yaml-file', action='store_true',
+    parser_report.add_argument('-y', '--yaml', action='store_true',
                                help="Create a report in yaml format")
-    parser_report.add_argument('-J', '--json-file', action='store_true',
+    parser_report.add_argument('-j', '--json', action='store_true',
                                help="Create a report in json format")
+    parser_report.add_argument('-f', '--file', default=None,
+                               help="Write the report to a file; "
+                               "If no file is given the default file in "
+                               "utils/constants.py will be used")
     parser_report.set_defaults(name='report')
     args = parser.parse_args()
 


### PR DESCRIPTION
To support running in a docker container, the output of tern needs
to be sent to stdout. In general, it is reasonable to allow tern to
send results to stdout by default.

- Changed write_report function to take arguments and switch file
names based on them
- Have generate_report function return the report rather than
write to a file
- Added function report_out to handle where the report goes
- Replaced generate_report with report_out in the execution
- Modified CLI arguments for yaml and json formats to be more
clear
- Added a CLI option to write out to a file

Resolves #165

Signed-off-by: Nisha K <nishak@vmware.com>