### PR TITLE
Fixed issues discovered by security linter

### DIFF
--- a/classes/image_layer.py
+++ b/classes/image_layer.py
@@ -1,5 +1,5 @@
 '''
-Copyright (c) 2017-2018 VMware, Inc. All Rights Reserved.
+Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
 SPDX-License-Identifier: BSD-2-Clause
 '''
 import os
@@ -88,14 +88,12 @@ class ImageLayer(object):
         self.__import_str = import_str
 
     def add_package(self, package):
-        try:
-            assert isinstance(package, Package), \
-                   'Object type is {0}, should be Package'.format(
-                       type(package))
+        if isinstance(package, Package):
             if package.name not in self.get_package_names():
                 self.__packages.append(package)
-        except AssertionError:
-            raise
+        else:
+            raise TypeError('Object type is {0}, should be Package'.format(
+                       type(package)))
 
     def remove_package(self, package_name):
         rem_index = 0

--- a/classes/notice_origin.py
+++ b/classes/notice_origin.py
@@ -1,11 +1,12 @@
 '''
-Copyright (c) 2017-2018 VMware, Inc. All Rights Reserved.
+Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
 SPDX-License-Identifier: BSD-2-Clause
 '''
 
 from report import formats
 
 from .notice import Notice
+
 
 class NoticeOrigin(object):
     '''The origin of a notice
@@ -30,12 +31,11 @@ class NoticeOrigin(object):
         return self.__notices
 
     def add_notice(self, notice):
-        try:
-            assert isinstance(notice, Notice), \
-                   'Object type is {0}, should be Notice'.format(type(notice))
+        if isinstance(notice, Notice):
             self.__notices.append(notice)
-        except AssertionError:
-            raise
+        else:
+            raise TypeError('Object type is {0}, should be Notice'.format(
+                type(notice)))
 
     def print_notices(self):
         '''Using the notice format, return a formatted string'''
@@ -53,7 +53,10 @@ class NoticeOrigin(object):
             if notice.level == 'hint':
                 hints = hints + notice.message
         notice_msg = formats.notice_format.format(
-            origin=self.origin_str, info=info, warnings=warnings, errors=errors,
+            origin=self.origin_str,
+            info=info,
+            warnings=warnings,
+            errors=errors,
             hints=hints)
         return notice_msg
 

--- a/tests/test_class_image_layer.py
+++ b/tests/test_class_image_layer.py
@@ -1,5 +1,5 @@
 '''
-Copyright (c) 2017-2018 VMware, Inc. All Rights Reserved.
+Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
 SPDX-License-Identifier: BSD-2-Clause
 '''
 
@@ -30,9 +30,12 @@ class TestClassImageLayer(unittest.TestCase):
         self.assertEqual(self.layer.created_by, 'some string')
 
     def testAddPackage(self):
+        err = "Object type String, should be Package"
         p1 = Package('x')
         self.layer.add_package(p1)
         self.assertEqual(len(self.layer.packages), 1)
+        with self.assertRaises(TypeError, msg=err):
+            self.layer.add_package("not_a_package")
 
     def testRemovePackage(self):
         p1 = Package('x')

--- a/tests/test_class_notice_origin.py
+++ b/tests/test_class_notice_origin.py
@@ -1,5 +1,5 @@
 '''
-Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+Copyright (c) 2018-2019 VMware, Inc. All Rights Reserved.
 SPDX-License-Identifier: BSD-2-Clause
 '''
 
@@ -8,7 +8,6 @@ import unittest
 from report import formats
 
 from classes.notice import Notice
-from classes.notice import NoticeException
 from classes.notice_origin import NoticeOrigin
 
 
@@ -38,7 +37,7 @@ class TestClassNoticeOrigin(unittest.TestCase):
 
     def testAddNotice(self):
         exp = "Object type String, should be Notice"
-        with self.assertRaises(AssertionError, msg=exp) as ex:
+        with self.assertRaises(TypeError, msg=exp):
             self.notice_origin.add_notice("not_a_notice")
 
         self.notice_origin.add_notice(self.notice_info)

--- a/utils/cache.py
+++ b/utils/cache.py
@@ -28,7 +28,7 @@ def load():
     '''Load the cache'''
     global cache
     with open(os.path.abspath(cache_file)) as f:
-        cache = yaml.load(f)
+        cache = yaml.safe_load(f)
 
 
 def get_packages(sha):


### PR DESCRIPTION
On running the bandit security linter on the code, a couple of
asset statements and the use of yaml.load came up. Fixing those
issues.

- Changed yaml.load to yaml.safe_load
- Replaced try-except loops with if-else statements
- Fixed test for notice_origin class
- Added the test to check if the object is of the correct type in
image_layer class test

Resolves #169

Signed-off-by: Nisha K <nishak@vmware.com>