### PR TITLE
Dismiss security issues for subprocess and random

### DIFF
--- a/src/classes/docker_image.py
+++ b/src/classes/docker_image.py
@@ -5,7 +5,7 @@ SPDX-License-Identifier: BSD-2-Clause
 
 import json
 import os
-import subprocess
+import subprocess  # nosec
 
 from utils.general import pushd
 from utils.constants import temp_folder

--- a/src/command_lib/command_lib.py
+++ b/src/command_lib/command_lib.py
@@ -5,7 +5,7 @@ SPDX-License-Identifier: BSD-2-Clause
 
 import logging
 import os
-import subprocess
+import subprocess  # nosec
 import yaml
 
 from utils import container

--- a/src/docker_helpers.py
+++ b/src/docker_helpers.py
@@ -5,7 +5,7 @@ SPDX-License-Identifier: BSD-2-Clause
 import logging
 import os
 import re
-import subprocess
+import subprocess  # nosec
 
 from classes.docker_image import DockerImage
 from classes.notice import Notice

--- a/src/report/report.py
+++ b/src/report/report.py
@@ -7,7 +7,7 @@ import docker
 import logging
 import os
 import shutil
-import subprocess
+import subprocess  # nosec
 import sys
 
 from report import content

--- a/src/tools/verify_invoke.py
+++ b/src/tools/verify_invoke.py
@@ -4,7 +4,7 @@ SPDX-License-Identifier: BSD-2-Clause
 '''
 
 import argparse
-import subprocess
+import subprocess  # nosec
 
 from utils import constants
 from command_lib import command_lib

--- a/src/utils/general.py
+++ b/src/utils/general.py
@@ -5,7 +5,7 @@ SPDX-License-Identifier: BSD-2-Clause
 import os
 import random
 import re
-import subprocess
+import subprocess  # nosec
 
 from contextlib import contextmanager
 
@@ -22,7 +22,7 @@ def pushd(path):
 
 
 def initialize_names():
-    randint = random.randint(10000, 99999)
+    randint = random.randint(10000, 99999)  # nosec
     constants.image = constants.image + "_" + str(randint)
     constants.tag = constants.tag + "_" + str(randint)
     constants.container = constants.container + "_" + str(randint)
@@ -77,7 +77,7 @@ def get_git_rev():
     '''Assuming we are operating within a git repository, get the SHA
     of the current commit'''
     command = ['git', 'show', '--format=%H', 'HEAD']
-    output = subprocess.check_output(command)
+    output = subprocess.check_output(command)  # nosec
     if type(output) == bytes:
         output = output.decode('utf-8')
     return output.split('\n').pop(0)

--- a/src/utils/rootfs.py
+++ b/src/utils/rootfs.py
@@ -5,7 +5,7 @@ SPDX-License-Identifier: BSD-2-Clause
 import hashlib
 import logging
 import os
-import subprocess
+import subprocess  # nosec
 import tarfile
 
 from . import constants
@@ -50,9 +50,9 @@ def root_command(command, *extra):
         full_cmd.append(arg)
     # invoke
     logger.debug("Running command: " + ' '.join(full_cmd))
-    pipes = subprocess.Popen(full_cmd, stdout=subprocess.PIPE,
+    pipes = subprocess.Popen(full_cmd, stdout=subprocess.PIPE,  # nosec
                              stderr=subprocess.PIPE)
-    result, error = pipes.communicate()
+    result, error = pipes.communicate()  # nosec
     if error:
         raise subprocess.CalledProcessError(1, cmd=full_cmd, output=error)
     else:


### PR DESCRIPTION
Python module subprocess is used for invoking system commands which
tern uses to analyze container images. So it can't do without it.

Python module random is just ised to create a unique tag for an image
should tern be used to build one from a given Dockerfile.

No PEP8 errors were found from the inline # nosec comments

Signed-off-by: Nisha K <nishak@vmware.com>