### PR TITLE
Add development requirements file

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,8 @@
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Pull in the runtime dependencies
+-r requirements.txt
+
+# For development work, pull in dev support utilities
+prospector==1.1.6.2


### PR DESCRIPTION
Added the file "dev-requirements.txt" listing the dependencies
needed when developing Tern rather than using Tern.  The standard
run-time requirements are referenced via an embedded "-r" option.

The naming allows tab completion:

    $ pip install -r dev<TAB>

The alternative name "requirements-dev.txt" would require a little
extra typing.

The dev orient requirement included in this commit is

    prospector==1.1.6.2

A utility to apply style checkers (pep8, pylint, etc).  See the
project page https://github.com/PyCQA/prospector

Signed-off-by: Michael Rohan <mrohan@vmware.com>