### PR TITLE
Resolve code check isues for src/utils/rootfs.py

### DIFF
--- a/tern/utils/rootfs.py
+++ b/tern/utils/rootfs.py
@@ -1,7 +1,10 @@
-'''
-Copyright (c) 2017-2018 VMware, Inc. All Rights Reserved.
-SPDX-License-Identifier: BSD-2-Clause
-'''
+#
+# Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+#
+"""
+Operations to mount container filesystems and run commands against them
+"""
 import hashlib
 import logging
 import os
@@ -9,10 +12,7 @@ import subprocess  # nosec
 import tarfile
 import pkg_resources
 
-from . import constants
-'''
-Operations to mount container filesystems and run commands against them
-'''
+from tern.utils import constants
 
 # remove root filesystems
 remove = ['rm', '-rf']
@@ -50,7 +50,7 @@ def root_command(command, *extra):
     for arg in extra:
         full_cmd.append(arg)
     # invoke
-    logger.debug("Running command: " + ' '.join(full_cmd))
+    logger.debug("Running command: %s", ' '.join(full_cmd))
     pipes = subprocess.Popen(full_cmd, stdout=subprocess.PIPE,  # nosec
                              stderr=subprocess.PIPE)
     result, error = pipes.communicate()  # nosec
@@ -98,7 +98,7 @@ def prep_rootfs(rootfs_dir):
         root_command(host_dns, os.path.join(
             rootfs_path, constants.resolv_path[1:]))
     except subprocess.CalledProcessError as error:
-        logger.error(error.output)
+        logger.error("%s", error.output)
         raise
 
 
@@ -183,5 +183,5 @@ def calc_fs_hash(fs_path):
         with open(hash_file, 'w') as f:
             f.write(hash_contents.decode('utf-8'))
         return file_name
-    except subprocess.CalledProcessError:
+    except subprocess.CalledProcessError:  # pylint: disable=try-except-raise
         raise


### PR DESCRIPTION
The issues raised by prospector for "src/utils/rootfs.py" are:

    src/utils/rootfs.py
      Line: 14
        pylint: pointless-string-statement / String statement has no effect
      Line: 52
        pylint: logging-not-lazy / Specify string format arguments as logging function parameters (col 4)
      Line: 183
        pylint: try-except-raise / The except handler raises immediately (col 4)

This change resolves these issues.  The final warning is suppressed
as this is a coding pattern common for Tern (could, alternatively,
add a log message).

Signed-off-by: Michael Rohan <mrohan@vmware.com>