### PR TITLE
Resolve code check isues for src/utils/metadata.py

### DIFF
--- a/tern/utils/metadata.py
+++ b/tern/utils/metadata.py
@@ -1,15 +1,14 @@
-'''
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
-SPDX-License-Identifier: BSD-2-Clause
-'''
+#
+# Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+#
+"""
+Container metadata operations
+"""
 
 import os
 import shutil
-from utils.constants import temp_folder
-
-'''
-Container metadata operations
-'''
+from tern.utils.constants import temp_folder
 
 
 def clean_temp():


### PR DESCRIPTION
The issues raised by prospector for "src/utils/metadata.py" are:

    tern/utils/metadata.py
      Line: 8
        pylint: import-error / Unable to import 'utils.constants'
      Line: 12
        pylint: pointless-string-statement / String statement has no effect

This change resolves these issues.  Also added a encoding comment
to rootfs.py (update to previous commit).

Signed-off-by: Michael Rohan <mrohan@vmware.com>