### PR TITLE
Add initial support for rpm based distros

### DIFF
--- a/tern/command_lib/base.yml
+++ b/tern/command_lib/base.yml
@@ -146,3 +146,33 @@ pacman:
         container:
           - 'pacman -Qi 2>/dev/null | sed -n "/URL/s/URL.*: //p" '
     delimiter: "\n"
+
+# rpm ----------------------------------------------------------------------
+rpm:
+  path:
+    - 'usr/bin/rpm'
+  shell: '/usr/bin/sh'
+  names:
+    invoke:
+      1:
+        container:
+          - 'rpm --query --all --queryformat "%{name}\n" 2>/dev/null'
+    delimiter: "\n"
+  versions:
+    invoke:
+      1:
+        container:
+          - 'rpm --query --all --queryformat "%{version}\n" 2>/dev/null'
+    delimiter: "\n"
+  licenses:
+    invoke:
+      1:
+        container:
+          - 'rpm --query --all --queryformat "%{license}\n" 2>/dev/null'
+    delimiter: "\n"
+  src_urls:
+    invoke:
+      1:
+        container:
+          - 'rpm --query --all --queryformat "%{url}\n" 2>/dev/null'
+    delimiter: "\n"

--- a/tern/command_lib/snippets.yml
+++ b/tern/command_lib/snippets.yml
@@ -91,8 +91,24 @@ apk:
               - 'apk -R info python 2>/dev/null | tail -n +2 | head -n -1 | cut -f2 -d":" | cut -f1 -d"."'
         delimiter: "\n"
 
-
 pacman:
   install: '-Syu'
   remove: '-Rcs'
   packages: 'pacman'
+
+yum:
+  install: 'install'
+  remove: 'remove'
+  ignore:
+    - 'check-update'
+    - 'clean'
+  packages: 'rpm'
+
+dnf:
+  install: 'install'
+  remove: 'remove'
+  ignore:
+    - 'check-update'
+    - 'clean'
+  packages: 'rpm'
+


### PR DESCRIPTION
Should support yum, and dnf from Red Hat Enterprise Linux, CentOS, and fedora.

I think I covered the sections needed. I wasn't sure how to actually test my changes locally to verify they work as expected.

fixes #181 