### PR TITLE
tests: Fixed some simple class tests

### DIFF
--- a/tests/test_class_image.py
+++ b/tests/test_class_image.py
@@ -1,30 +1,31 @@
 '''
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
 SPDX-License-Identifier: BSD-2-Clause
 '''
 
 import unittest
 
-from classes.image import Image
+from tern.classes.image import Image
+from tern.classes.origins import Origins
 
 
 class TestClassImage(unittest.TestCase):
 
     def setUp(self):
         '''Test a generic Image class'''
-        self.image = Image('debian:jessie')
+        self.image = Image('1234abcd')
 
     def tearDown(self):
         del self.image
 
     def testInstance(self):
-        self.assertEqual(self.image.repotag, 'debian:jessie')
-        self.assertFalse(self.image.id)
+        self.assertEqual(self.image.id, '1234abcd')
+        self.assertFalse(self.image.name)
         self.assertFalse(self.image.manifest)
-        self.assertFalse(self.image.repotags)
+        self.assertFalse(self.image.tag)
         self.assertFalse(self.image.config)
         self.assertFalse(self.image.layers)
-        self.assertFalse(self.image.history)
+        self.assertIsInstance(self.image.origins, Origins)
 
 
 if __name__ == '__main__':

--- a/tests/test_class_image_layer.py
+++ b/tests/test_class_image_layer.py
@@ -5,8 +5,8 @@ SPDX-License-Identifier: BSD-2-Clause
 
 import unittest
 
-from classes.image_layer import ImageLayer
-from classes.package import Package
+from tern.classes.image_layer import ImageLayer
+from tern.classes.package import Package
 
 
 class TestClassImageLayer(unittest.TestCase):

--- a/tests/test_class_notice.py
+++ b/tests/test_class_notice.py
@@ -1,12 +1,12 @@
 '''
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
 SPDX-License-Identifier: BSD-2-Clause
 '''
 
 import unittest
 
-from classes.notice import Notice
-from classes.notice import NoticeException
+from tern.classes.notice import Notice
+from tern.classes.notice import NoticeException
 
 
 class TestClassNotice(unittest.TestCase):
@@ -33,13 +33,14 @@ class TestClassNotice(unittest.TestCase):
         self.notice.level = 'warning'
         self.assertEqual(self.notice.message, 'tag')
         self.assertEqual(self.notice.level, 'warning')
-    
+
     def testToDict(self):
         self.notice.message = 'tag'
         self.notice.level = 'warning'
         dict = self.notice.to_dict()
-        self.assertEqual(dict.message, 'tag')
-        self.assertEqual(dict.level, 'warning')
+        self.assertEqual(dict['message'], 'tag')
+        self.assertEqual(dict['level'], 'warning')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_class_notice_origin.py
+++ b/tests/test_class_notice_origin.py
@@ -5,10 +5,9 @@ SPDX-License-Identifier: BSD-2-Clause
 
 import unittest
 
-from report import formats
-
-from classes.notice import Notice
-from classes.notice_origin import NoticeOrigin
+from tern.report import formats
+from tern.classes.notice import Notice
+from tern.classes.notice_origin import NoticeOrigin
 
 
 class TestClassNoticeOrigin(unittest.TestCase):

--- a/tests/test_class_package.py
+++ b/tests/test_class_package.py
@@ -1,11 +1,11 @@
 '''
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
 SPDX-License-Identifier: BSD-2-Clause
 '''
 
 import unittest
 
-from classes.package import Package
+from tern.classes.package import Package
 
 
 class TestClassPackage(unittest.TestCase):


### PR DESCRIPTION
test_class_image.py:
  - Bumped copyright year
  - Used full module path
  - Added Origins class import
  - Updated test for instantiating the base image class
test_class_image_layer.py:
  - Used full module path
test_class_notice.py:
  - Bumped copyright year
  - Used full module path
  - Fixed test for to_dict method
test_class_notice_origin.py:
  - Used full module path plus some rearranging of module import
    statements
test_class_package.py:
  - Bumped copyright year
  - Used full module path

Signed-off-by: Nisha K <nishak@vmware.com>