### PR TITLE
Updated requirements to direct dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,12 @@
-certifi==2018.11.29
-chardet==3.0.4
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Please only add direct dependencies here, i.e., do not update with the
+# output of `pip freeze`.  When updating dependency versions, have the
+# transitive dependencies listed make it more difficult to figure out
+# what should be updated.
+#
+
 docker==3.7.0
-docker-pycreds==0.4.0
-idna==2.8
 PyYAML==3.13
 requests==2.21.0
-six==1.12.0
-urllib3==1.24.1
-websocket-client==0.54.0


### PR DESCRIPTION
Updated the contents of the requirements.txt file to list just the
direct dependencies.  This will make it easier to see which
dependencies can be updated, e.g., via `pip list -o`