### PR TITLE
Adding 'attr' install in vagrant bootstrap.

### DIFF
--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -7,8 +7,8 @@ sudo apt-get update
 # Upgrade all currently installed packages
 sudo apt-get -y upgrade
 
-# Python3 versions
-sudo apt-get install -y python3 python3-pip python3-venv
+# Python3 versions and system dependencies
+sudo apt-get install -y python3 python3-pip python3-venv attr
 
 # Install Docker
 sudo apt-get install -y docker.io


### PR DESCRIPTION
fs_hash.sh uses getfattr to collect detailed file attributes. This
functionality is not available on native ubuntu so bootstrap has to
take care of installing it on the VM.

As 'attr' library was not available on the VM, the dependency to run
'tern report' was missing. That resulted in failure to generate report
with 'Cannot retrieve full image metadata'. fs_hash.sh collects detailed
file attributes using 'attr' library. As this dependency was not met,
the command used to return error.

Resolves: #220

Signed-off-by: Ravi Parikh <parikhr@vmware.com>