### PR TITLE
Resolve code check issues for tern/__main__.py

### DIFF
--- a/tern/utils/dockerfile.py
+++ b/tern/utils/dockerfile.py
@@ -1,11 +1,12 @@
-'''
-Copyright (c) 2017-2018 VMware, Inc. All Rights Reserved.
-SPDX-License-Identifier: BSD-2-Clause
-'''
-import re
-'''
+#
+# Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+#
+"""
 Dockerfile parser and information retrieval
-'''
+"""
+
+import re
 
 directives = ['FROM',
               'ARG',
@@ -27,7 +28,7 @@ tabs = re.compile('\t')
 
 # regex strings
 cleaning = '[\t\\\\]'
-bash_var = '[\$\{\}]'
+bash_var = '[\$\{\}]'  # noqa
 
 # strings
 tag_separator = ':'
@@ -51,10 +52,7 @@ def get_command_list(dockerfile_name):
                 command = command + line
         # check if this line has an indentation
         # comments don't count
-        if line_indent.match(line):
-            command_cont = True
-        else:
-            command_cont = False
+        command_cont = bool(line_indent.match(line))
 
         # check if there is a command or not
         if command == '':
@@ -149,8 +147,8 @@ def get_base_image_tag(base_instructions):
             build_args.update({key_value[0]: key_value[1]})
     # replace any variables in FROM with value
     from_instruction = re.sub(bash_var, '', from_instruction)
-    for key in build_args.keys():
-        from_instruction = from_instruction.replace(key, build_args[key])
+    for key, value in build_args.items():
+        from_instruction = from_instruction.replace(key, value)
     # check if the base image has a tag
     image_tag_list = from_instruction.split(tag_separator)
     if len(image_tag_list) == 1:


### PR DESCRIPTION
The issues raised by prospector for "tern/__main__.py" are:

    tern/utils/dockerfile.py
      Line: 8
        pylint: pointless-string-statement / String statement has no
                effect
      Line: 30
        pep8: W605 / invalid escape sequence '\$' (col 3)
        pep8: W605 / invalid escape sequence '\{' (col 5)
        pep8: W605 / invalid escape sequence '\}' (col 7)
      Line: 54
        pylint: simplifiable-if-statement / The if statement can be
                replaced with 'var = bool(test)' (col 8)
      Line: 152
        pylint: consider-iterating-dictionary / Consider iterating
                the dictionary directly instead of calling .keys()
                (col 15)

This change resolves these issues.

NOTE: The PEP8 issues wrt escape sequences were suppressed rather
than resolved.  It was clear what testing would be needed if this
string were replaced with a raw string: r'...'

Signed-off-by: Michael Rohan <mrohan@vmware.com>