### PR TITLE
tests: Replace Copyright docstring with comments

### DIFF
--- a/tests/test_class_command.py
+++ b/tests/test_class_command.py
@@ -1,7 +1,7 @@
-'''
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
-SPDX-License-Identifier: BSD-2-Clause
-'''
+#
+# Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+#
 import unittest
 
 from classes.command import Command

--- a/tests/test_class_docker_image.py
+++ b/tests/test_class_docker_image.py
@@ -1,7 +1,7 @@
-'''
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
-SPDX-License-Identifier: BSD-2-Clause
-'''
+#
+# Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+#
 
 import unittest
 import subprocess

--- a/tests/test_class_docker_image.py
+++ b/tests/test_class_docker_image.py
@@ -4,7 +4,7 @@
 #
 
 import unittest
-import subprocess
+import subprocess  # nosec
 
 from classes.docker_image import DockerImage
 from utils.container import docker_command

--- a/tests/test_class_image.py
+++ b/tests/test_class_image.py
@@ -1,7 +1,7 @@
-'''
-Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
-SPDX-License-Identifier: BSD-2-Clause
-'''
+#
+# Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+#
 
 import unittest
 

--- a/tests/test_class_image_layer.py
+++ b/tests/test_class_image_layer.py
@@ -1,7 +1,7 @@
-'''
-Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
-SPDX-License-Identifier: BSD-2-Clause
-'''
+#
+# Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+#
 
 import unittest
 

--- a/tests/test_class_notice.py
+++ b/tests/test_class_notice.py
@@ -1,7 +1,7 @@
-'''
-Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
-SPDX-License-Identifier: BSD-2-Clause
-'''
+#
+# Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+#
 
 import unittest
 

--- a/tests/test_class_notice_origin.py
+++ b/tests/test_class_notice_origin.py
@@ -1,7 +1,7 @@
-'''
-Copyright (c) 2018-2019 VMware, Inc. All Rights Reserved.
-SPDX-License-Identifier: BSD-2-Clause
-'''
+#
+# Copyright (c) 2018-2019 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+#
 
 import unittest
 

--- a/tests/test_class_package.py
+++ b/tests/test_class_package.py
@@ -1,7 +1,7 @@
-'''
-Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
-SPDX-License-Identifier: BSD-2-Clause
-'''
+#
+# Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+#
 
 import unittest
 

--- a/tests/test_util_commands.py
+++ b/tests/test_util_commands.py
@@ -1,7 +1,7 @@
-'''
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
-SPDX-License-Identifier: BSD-2-Clause
-'''
+#
+# Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+#
 
 import unittest
 

--- a/tests/test_util_metadata.py
+++ b/tests/test_util_metadata.py
@@ -1,7 +1,7 @@
-'''
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
-SPDX-License-Identifier: BSD-2-Clause
-'''
+#
+# Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+#
 
 import unittest
 


### PR DESCRIPTION
PEP8 says use triple quotes for docstrings. The Copyright notice
isn't a docstring. Replacing with comments instead. This now
matches the coding style for the rest of the project

Signed-off-by: Nisha K <nishak@vmware.com>