### PR TITLE
Removing an unused argument from get_base_bin.

### DIFF
--- a/tern/common.py
+++ b/tern/common.py
@@ -65,7 +65,7 @@ def save_to_cache(image):
             cache.add_layer(layer)
 
 
-def get_base_bin(base_layer):  # pylint: disable=unused-argument
+def get_base_bin():
     '''Given the base layer object, find the binary used to identify the
     base OS layer. Assume that the layer filesystem is mounted'''
     binary = ''

--- a/tern/report/report.py
+++ b/tern/report/report.py
@@ -188,7 +188,7 @@ def analyze_docker_image(image_obj, redo=False, dockerfile=False):  # pylint: di
     master_list = []
     # find the binary by mounting the base layer
     target = rootfs.mount_base_layer(image_obj.layers[0].tar_file)
-    binary = common.get_base_bin(image_obj.layers[0])
+    binary = common.get_base_bin()
     # set up a notice origin referring to the base command library listing
     origin_command_lib = formats.invoking_base_commands
     # set up a notice origin for the first layer


### PR DESCRIPTION
Removing an unused argument from function get_base_bin
in common.py. Also removing relevant pylint comment.

Resolves: #218

Signed-off-by: Ravi Parikh <parikhr@vmware.com>