### PR TITLE
classes: Removed unnecessary redefined-builtin

### DIFF
--- a/tern/classes/docker_image.py
+++ b/tern/classes/docker_image.py
@@ -25,7 +25,7 @@ class DockerImage(Image):
         history: a list of commands used to create the filesystem layers
         to_dict: return a dict representation of the object
     '''
-    def __init__(self, repotag=None, image_id=None):  # pylint: disable=redefined-builtin
+    def __init__(self, repotag=None, image_id=None):
         '''Initialize using repotag and image_id'''
         super().__init__(image_id)
         self.__repotag = repotag

--- a/tern/classes/image.py
+++ b/tern/classes/image.py
@@ -19,7 +19,7 @@ class Image:
         get_layer_diff_ids: returns a list of layer diff ids only
         to_dict: return a python dictionary representation of the image
     '''
-    def __init__(self, image_id=None):  # pylint: disable=redefined-builtin
+    def __init__(self, image_id=None):
         '''Either initialize using id'''
         self._image_id = image_id
         self._name = ''


### PR DESCRIPTION
The previous change replaced `id` with `image_id`. So pylint does
not see this as a redefined-builtin.

Signed-off-by: Nisha K <nishak@vmware.com>