### PR TITLE
Renaming license to pkg_license in all classes and tests

### DIFF
--- a/tern/classes/package.py
+++ b/tern/classes/package.py
@@ -12,7 +12,7 @@ class Package:
     attributes:
         name: package name
         version: package version
-        license: package license
+        pkg_license: package license
         src_url: package source url
         origins: a list of NoticeOrigin objects
 
@@ -23,7 +23,7 @@ class Package:
     def __init__(self, name):
         self.__name = name
         self.__version = ''
-        self.__license = ''
+        self.__pkg_license = ''
         self.__src_url = ''
         self.__origins = Origins()
 
@@ -40,12 +40,12 @@ class Package:
         self.__version = version
 
     @property
-    def license(self):
-        return self.__license
+    def pkg_license(self):
+        return self.__pkg_license
 
-    @license.setter
-    def license(self, license):  # pylint: disable=redefined-builtin
-        self.__license = license
+    @pkg_license.setter
+    def pkg_license(self, pkg_license):  
+        self.__pkg_license =pkg_license
 
     @property
     def src_url(self):
@@ -86,7 +86,7 @@ class Package:
         '''The package dict looks like this:
             name: <name>
             version: <version>
-            license: <license string>
+            pkg_license: <packagelicense string>
             src_url: <source url>
         the way to use this method is to instantiate the class with the
         name and then give it a package dictionary to fill in the rest
@@ -95,7 +95,7 @@ class Package:
         success = True
         if self.name == package_dict['name']:
             self.version = package_dict['version']
-            self.license = package_dict['license']
+            self.pkg_license = package_dict['pkg_license']
             self.src_url = package_dict['src_url']
         else:
             success = False

--- a/tests/test_class_package.py
+++ b/tests/test_class_package.py
@@ -15,7 +15,7 @@ class TestClassPackage(unittest.TestCase):
     def setUp(self):
         self.p1 = Package('p1')
         self.p1.version = '1.0'
-        self.p1.license = 'Apache 2.0'
+        self.p1.pkg_license = 'Apache 2.0'
         self.p1.src_url = 'github.com'
 
         self.p2 = Package('p2')
@@ -28,28 +28,28 @@ class TestClassPackage(unittest.TestCase):
         self.assertEqual(self.p2.name, 'p2')
         self.assertFalse(self.p2.version)
         self.assertFalse(self.p2.src_url)
-        self.assertFalse(self.p2.license)
+        self.assertFalse(self.p2.pkg_license)
 
     def testSetters(self):
         self.assertRaises(AttributeError, setattr, self.p2, 'name', 'y')
         self.p2.version = '2.0'
         self.assertEqual(self.p2.version, '2.0')
-        self.p2.license = 'Apache 2.0'
-        self.assertEqual(self.p2.license, 'Apache 2.0')
+        self.p2.pkg_license = 'Apache 2.0'
+        self.assertEqual(self.p2.pkg_license, 'Apache 2.0')
         self.p2.src_url = 'github.com'
         self.assertEqual(self.p2.src_url, 'github.com')
 
     def testGetters(self):
         self.assertEqual(self.p1.name, 'p1')
         self.assertEqual(self.p1.version, '1.0')
-        self.assertEqual(self.p1.license, 'Apache 2.0')
+        self.assertEqual(self.p1.pkg_license, 'Apache 2.0')
         self.assertEqual(self.p1.src_url, 'github.com')
 
     def testToDict(self):
         a_dict = self.p1.to_dict()
         self.assertEqual(a_dict['name'], 'p1')
         self.assertEqual(a_dict['version'], '1.0')
-        self.assertEqual(a_dict['license'], 'Apache 2.0')
+        self.assertEqual(a_dict['pkg_license'], 'Apache 2.0')
         self.assertEqual(a_dict['src_url'], 'github.com')
         self.assertFalse(a_dict['origins'])
 
@@ -67,10 +67,10 @@ class TestClassPackage(unittest.TestCase):
 
     def testIsEqual(self):
         p = Package('p2')
-        p.license = 'TestLicense'
+        p.pkg_license = 'Testpkg_license'
         p.version = '1.0'
         p.src_url = 'TestUrl'
-        self.p2.license = 'TestLicense'
+        self.p2.pkg_license = 'Testpkg_license'
         self.p2.version = '2.0'
         self.p2.src_url = 'TestUrl'
         self.assertFalse(self.p2.is_equal(p))

--- a/tests/test_class_template.py
+++ b/tests/test_class_template.py
@@ -25,7 +25,7 @@ class TestClassTemplate(unittest.TestCase):
         mapping = self.template1.package()
         self.assertEqual(mapping['name'], 'package.name')
         self.assertEqual(mapping['version'], 'package.version')
-        self.assertEqual(mapping['license'], 'package.license')
+        self.assertEqual(mapping['pkg_license'], 'package.pkg_license')
 
     def testImageLayer(self):
         mapping = self.template1.image_layer()
@@ -35,7 +35,7 @@ class TestClassTemplate(unittest.TestCase):
 
     def testImage(self):
         mapping = self.template1.image()
-        self.assertEqual(mapping['id'], 'image.id')
+        self.assertEqual(mapping['image_id'], 'image.id')
         self.assertEqual(mapping['layers'], 'image.layers')
 
     def testNotice(self):

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -28,7 +28,7 @@ class TestTemplate1(Template):
     def package(self):
         return {'name': 'package.name',
                 'version': 'package.version',
-                'license': 'package.license'}
+                'pkg_license': 'package.license'}
 
     def image_layer(self):
         return {'diff_id': 'layer.diff',
@@ -36,7 +36,7 @@ class TestTemplate1(Template):
                 'packages': 'layer.packages'}
 
     def image(self):
-        return {'id': 'image.id',
+        return {'image_id': 'image.id',
                 'layers': 'image.layers'}
 
 
@@ -45,7 +45,7 @@ class TestTemplate2(Template):
     def package(self):
         mapping = {'name': 'package.name',
                    'version': 'package.version',
-                   'license': 'package.license',
+                   'pkg_license': 'package.license',
                    'src_url': 'package.url'}
         # we update the mapping with another defined mapping
         mapping.update(self.origins())
@@ -60,7 +60,7 @@ class TestTemplate2(Template):
         return mapping
 
     def image(self):
-        mapping = {'id': 'image.id',
+        mapping = {'image_id': 'image.id',
                    'layers': 'image.layers'}
         # we update the mapping with another defined mapping
         mapping.update(self.origins())


### PR DESCRIPTION
This PR adds renaming of license to pkg_license in package class properties and corresponding tests. After renaming, I have verified that all tests in tests.test_class_package.py passed.

Resolves issue #213

Signed-off-by: Manisha Tripathy <tripathym@vmware.com>