### PR TITLE
RFC: improve docker socket error handling

### DIFF
--- a/tern/__main__.py
+++ b/tern/__main__.py
@@ -11,8 +11,14 @@ Tern executable
 import argparse
 import logging
 import os
+import sys
 
-from tern.report import report
+try:
+    from tern.report import report
+except Exception as e:
+    print("Couldn't set up the report module:\n\t{}".format(e))
+    sys.exit(1)
+
 from tern.utils import cache
 from tern.utils import constants
 

--- a/tern/__main__.py
+++ b/tern/__main__.py
@@ -13,12 +13,6 @@ import logging
 import os
 import sys
 
-try:
-    from tern.report import report
-except Exception as e:
-    print("Couldn't set up the report module:\n\t{}".format(e))
-    sys.exit(1)
-
 from tern.utils import cache
 from tern.utils import constants
 
@@ -40,6 +34,13 @@ log_handler.setFormatter(formatter)
 console.setFormatter(formatter)
 
 logger.addHandler(log_handler)
+
+try:
+    from tern.report import report
+except Exception as e:
+    logger.addHandler(console)
+    logger.critical("Couldn't set up the report module:\n\t%s", e)
+    sys.exit(1)
 
 
 def do_main(args):

--- a/tern/report/report.py
+++ b/tern/report/report.py
@@ -13,11 +13,7 @@ import shutil
 import subprocess  # nosec
 import sys
 
-try:
-    from tern.utils import container
-except Exception:
-    raise
-
+from tern.utils import container
 from tern.report import content
 from tern.report import errors
 from tern.report import formats

--- a/tern/report/report.py
+++ b/tern/report/report.py
@@ -13,10 +13,14 @@ import shutil
 import subprocess  # nosec
 import sys
 
+try:
+    from tern.utils import container
+except Exception:
+    raise
+
 from tern.report import content
 from tern.report import errors
 from tern.report import formats
-from tern.utils import container
 from tern.utils import constants
 from tern.utils import cache
 from tern.utils import general

--- a/tern/utils/container.py
+++ b/tern/utils/container.py
@@ -32,12 +32,17 @@ logger = logging.getLogger(logger_name)
 client = None
 try:
     client = docker.from_env()
+    client.ping()
 except IOError:
     logger.critical("Docker daemon not running")
     raise Exception("Critical Error using Docker API. See logs for details")
 except OSError:  # pylint: disable=duplicate-except
     logger.critical("User has no access to docker unix socket")
     raise Exception("Critical Error using Docker API. See logs for details")
+except ConnectionError:
+    logger.critical("Can't connect to the Docker daemon!")
+    raise Exception("Critical Error using Docker API. See logs for details")
+
 
 
 def is_sudo():

--- a/tern/utils/container.py
+++ b/tern/utils/container.py
@@ -13,7 +13,7 @@ import os
 import pwd
 import tarfile
 import time
-from requests.exceptions import HTTPError
+from requests.exceptions import HTTPError, ConnectionError
 
 
 from tern.utils.constants import container
@@ -59,6 +59,8 @@ def check_container():
         return True
     except docker.errors.NotFound:
         return False
+    except (ConnectionRefusedError, ConnectionError):
+        return False
 
 
 def check_image(image_tag_string):
@@ -71,6 +73,9 @@ def check_image(image_tag_string):
         return True
     except docker.errors.ImageNotFound:
         return False
+    except (ConnectionRefusedError, ConnectionError):
+        return False
+
 
 
 def pull_image(image_tag_string):
@@ -83,6 +88,9 @@ def pull_image(image_tag_string):
     except docker.errors.ImageNotFound:
         logger.warning("No such image: \"%s\"", image_tag_string)
         return False
+    except (ConnectionRefusedError, ConnectionError):
+        return False
+
 
 
 def build_container(dockerfile, image_tag_string):

--- a/tern/utils/container.py
+++ b/tern/utils/container.py
@@ -13,7 +13,7 @@ import os
 import pwd
 import tarfile
 import time
-from requests.exceptions import HTTPError, ConnectionError
+from requests.exceptions import HTTPError
 
 
 from tern.utils.constants import container
@@ -33,16 +33,15 @@ client = None
 try:
     client = docker.from_env()
     client.ping()
+except ConnectionError:
+    logger.critical("Can't connect to the Docker daemon!")
+    raise Exception("Critical Error using Docker API. See logs for details")
 except IOError:
     logger.critical("Docker daemon not running")
     raise Exception("Critical Error using Docker API. See logs for details")
 except OSError:  # pylint: disable=duplicate-except
     logger.critical("User has no access to docker unix socket")
     raise Exception("Critical Error using Docker API. See logs for details")
-except ConnectionError:
-    logger.critical("Can't connect to the Docker daemon!")
-    raise Exception("Critical Error using Docker API. See logs for details")
-
 
 
 def is_sudo():
@@ -65,6 +64,7 @@ def check_container():
     except docker.errors.NotFound:
         return False
     except (ConnectionRefusedError, ConnectionError):
+        logger.warning("Lost connection to the docker socket!")
         return False
 
 
@@ -79,6 +79,7 @@ def check_image(image_tag_string):
     except docker.errors.ImageNotFound:
         return False
     except (ConnectionRefusedError, ConnectionError):
+        logger.warning("Lost connection to the docker socket!")
         return False
 
 
@@ -94,6 +95,7 @@ def pull_image(image_tag_string):
         logger.warning("No such image: \"%s\"", image_tag_string)
         return False
     except (ConnectionRefusedError, ConnectionError):
+        logger.warning("Lost connection to the docker socket!")
         return False
 
 


### PR DESCRIPTION
From issue #207. We can probably better handle a misconfigured docker daemon by
blowing up *and* telling the user that it's not possible to contact the docker
daemon. This is more friendly than the actual behavior, which is 3 nested
exceptions taking place...