### PR TITLE
Added get_package_id method to the Package class

### DIFF
--- a/tern/classes/package.py
+++ b/tern/classes/package.py
@@ -113,3 +113,9 @@ class Package:
             if value != other_pkg_dict[key]:
                 return False
         return True
+
+    def get_package_id(self):
+        '''This method returns a string of the name and version for a package
+        represented as "name.version". This method might be helpful when working
+        with SPDX documents that require a unique package identifier.'''
+        return "{0}.{1}".format(self.name, self.version)


### PR DESCRIPTION
This method will return a package name.version as
a string. It may be helpful for creating SPDX unique
package identifiers.

Resolves: #241
See also: #182

Signed-off-by: Rose Judge <rose.harber@gmail.com>