### PR TITLE
Allow for Copyright text metadata

### DIFF
--- a/tern/classes/package.py
+++ b/tern/classes/package.py
@@ -99,7 +99,7 @@ class Package:
         listed. If not then put a Notice object in the list of Origins
         package_dict should not contain 'name' '''
         for key, prop in prop_names(self):
-            if prop != 'name' and prop != 'origins':
+            if prop not in ('name', 'origins'):
                 if prop not in package_dict.keys():
                     self.origins.add_notice_to_origins(
                         self.name, Notice(

--- a/tern/classes/package.py
+++ b/tern/classes/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
+from tern.classes.notice import Notice
 from tern.classes.origins import Origins
 from tern.utils.general import prop_names
 
@@ -93,11 +94,25 @@ class Package:
             pkg_dict.update({'origins': self.origins.to_dict()})
         return pkg_dict
 
+    def __fill_properties(self, package_dict):
+        '''Check to see if the dictionary keys have all the properties
+        listed. If not then put a Notice object in the list of Origins
+        package_dict should not contain 'name' '''
+        for key, prop in prop_names(self):
+            if prop != 'name' and prop != 'origins':
+                if prop not in package_dict.keys():
+                    self.origins.add_notice_to_origins(
+                        self.name, Notice(
+                            "No metadata for key: {}".format(prop), 'warning'))
+                else:
+                    self.__dict__[key] = package_dict[prop]
+
     def fill(self, package_dict):
         '''The package dict looks like this:
             name: <name>
             version: <version>
-            pkg_license: <packagelicense string>
+            pkg_license: <package license string>
+            copyright: <package copyright text>
             src_url: <source url>
         the way to use this method is to instantiate the class with the
         name and then give it a package dictionary to fill in the rest
@@ -105,9 +120,7 @@ class Package:
         the object, false if not'''
         success = True
         if self.name == package_dict['name']:
-            self.version = package_dict['version']
-            self.pkg_license = package_dict['pkg_license']
-            self.src_url = package_dict['src_url']
+            self.__fill_properties(package_dict)
         else:
             success = False
         return success

--- a/tern/classes/package.py
+++ b/tern/classes/package.py
@@ -13,7 +13,8 @@ class Package:
     attributes:
         name: package name
         version: package version
-        pkg_license: package license
+        pkg_license: package license that is declared
+        copyright: copyright text
         src_url: package source url
         origins: a list of NoticeOrigin objects
 
@@ -25,6 +26,7 @@ class Package:
         self.__name = name
         self.__version = ''
         self.__pkg_license = ''
+        self.__copyright = ''
         self.__src_url = ''
         self.__origins = Origins()
 
@@ -45,8 +47,16 @@ class Package:
         return self.__pkg_license
 
     @pkg_license.setter
-    def pkg_license(self, pkg_license):  
-        self.__pkg_license =pkg_license
+    def pkg_license(self, pkg_license):
+        self.__pkg_license = pkg_license
+
+    @property
+    def copyright(self):
+        return self.__copyright
+
+    @copyright.setter
+    def copyright(self, text):
+        self.__copyright = text
 
     @property
     def src_url(self):

--- a/tern/command_lib/base.yml
+++ b/tern/command_lib/base.yml
@@ -73,7 +73,7 @@ dpkg:
           - "pkgs=`dpkg --get-selections | cut -f1 -d':' | awk '{print $1}'`"
           - "for p in $pkgs; do dpkg -l $p | awk 'NR>5 {print $3}'; done"
     delimiter: "\n"
-  licenses:
+  copyrights:
     invoke:
       1:
         container:

--- a/tern/command_lib/command_lib.py
+++ b/tern/command_lib/command_lib.py
@@ -22,7 +22,8 @@ from tern.report import errors
 # base image command library
 base_file = pkg_resources.resource_filename('tern', 'command_lib/base.yml')
 # general snippets in command library
-snippet_file = pkg_resources.resource_filename('tern', 'command_lib/snippets.yml')
+snippet_file = pkg_resources.resource_filename('tern',
+                                               'command_lib/snippets.yml')
 # command library
 command_lib = {'base': {}, 'snippets': {}}
 with open(os.path.abspath(base_file)) as f:
@@ -30,8 +31,8 @@ with open(os.path.abspath(base_file)) as f:
 with open(os.path.abspath(snippet_file)) as f:
     command_lib['snippets'] = yaml.safe_load(f)
 # list of package information keys that the command library can accomodate
-base_keys = {'names', 'versions', 'licenses', 'src_urls', 'srcs'}
-package_keys = {'name', 'version', 'src_url', 'license', 'src'}
+base_keys = {'names', 'versions', 'licenses', 'copyrights', 'src_urls', 'srcs'}
+package_keys = {'name', 'version', 'license', 'copyright', 'src_url', 'src'}
 
 # global logger
 logger = logging.getLogger(constants.logger_name)

--- a/tern/command_lib/snippets.yml
+++ b/tern/command_lib/snippets.yml
@@ -11,41 +11,8 @@ apt-get:
   remove: 'purge' # subcommand to remove a package
   ignore: # list of subcommands that don't add or remove packages
     - 'update' 
-  packages:
-    - name: default
-      version:
-        # either a version number or a script snippet
-        invoke:
-          1:
-            container:
-              - "dpkg -l {package} | awk 'NR>5 {print $3}'"
-      src_url:
-        invoke:
-          1:
-            container:
-              - "apt-get download --print-uris {package}"
-      license:
-        invoke:
-          1:
-            container:
-              - "cat /usr/share/doc/{package}/copyright"
-      deps:
-        invoke:
-          1:
-            container:
-              - "apt-cache depends --installed --no-suggests {package} | awk 'NR>1 {print $2}'"
-        delimiter: "\n"
-      src:
-        # copy_in: used to copy into the running container
-        copy_in:
-            - from: 'config/{image}/{tag}/sources.list'
-              to: '/etc/apt/sources.list'
-            - from: 'config/image/apt_get_sources.sh'
-              to: '/'
-        invoke:
-            1:
-              container:
-                - './apt_get_sources.sh {package}'
+  packages: 'dpkg' # refer to base.yml's method of collection
+
 tyum:
   install: 'install'
   remove: 'remove'
@@ -65,31 +32,7 @@ tdnf:
 apk:
   install: 'add'
   remove: 'del'
-  # ignore:
-  packages:
-    - name: default
-      version:
-        invoke:
-          1:
-            container:
-                # use double quotes when using awk
-              - "apk info {package} 2>/dev/null | head -1 | awk '{print $1}'"
-      license:
-        invoke:
-          1:
-            container:
-              - 'apk -a info {package} 2>/dev/null | tail -2 | head -1'
-      src_url:
-        invoke:
-          1:
-            container:
-              - 'apk info {package} 2>/dev/null | head -5 | tail -1'
-      deps:
-        invoke:
-          1:
-            container:
-              - 'apk -R info python 2>/dev/null | tail -n +2 | head -n -1 | cut -f2 -d":" | cut -f1 -d"."'
-        delimiter: "\n"
+  packages: 'apk'
 
 pacman:
   install: '-Syu'

--- a/tern/report/content.py
+++ b/tern/report/content.py
@@ -18,7 +18,7 @@ def print_invoke_list(info_dict, info):
     package information.
     info_dict: get_base_listing or get_command_listing from
     command_lib/command_lib.py
-    info: the required key (niames, versions, licenses, etc)'''
+    see command_lib/command_lib.py for a list of supported info items'''
     report = ''
     if 'invoke' in info_dict[info]:
         report = report + info + ':\n'
@@ -39,10 +39,9 @@ def print_base_invoke(key):
     the command_lib/base.yml'''
     info = command_lib.get_base_listing(key)
     report = ''
-    report = report + print_invoke_list(info, 'names')
-    report = report + print_invoke_list(info, 'versions')
-    report = report + print_invoke_list(info, 'licenses')
-    report = report + print_invoke_list(info, 'src_urls')
+    for item in command_lib.base_keys:
+        if item in info.keys():
+            report = report + print_invoke_list(info, item)
     report = report + '\n'
     return report
 
@@ -74,7 +73,9 @@ def print_package(pkg_obj, prefix):
         package_url=pkg_obj.src_url)
     notes = notes + prefix + formats.package_license.format(
         package_license=pkg_obj.pkg_license)
-    notes = notes + '\n'
+    notes = notes + prefix + formats.package_copyright.format(
+        package_copyright=pkg_obj.copyright)
+    notes = notes + '\n\n'
     return notes
 
 

--- a/tern/report/formats.py
+++ b/tern/report/formats.py
@@ -41,7 +41,8 @@ invoke_on_host = '''\ton host:\n'''
 package_name = '''Package: {package_name}\n'''
 package_version = '''Version: {package_version}\n'''
 package_url = '''Project URL: {package_url}\n'''
-package_license = '''License: {package_license}\n\n'''
+package_license = '''License: {package_license}\n'''
+package_copyright = '''Copyright Text: {package_copyright}\n'''
 # notes
 package_notes = '''Errors: {package_info_retrieval_errors}\n''' \
     '''Improvements: {package_info_reporting_improvements}\n'''

--- a/tern/report/report.py
+++ b/tern/report/report.py
@@ -308,7 +308,8 @@ def generate_report(args, *images):
 
 def generate_verbose(is_summary, images):
     '''Generate a verbose report'''
-    report = formats.disclaimer.format(version_info=general.get_git_rev_or_version())
+    report = formats.disclaimer.format(
+        version_info=general.get_git_rev_or_version())
     if is_summary:
         logger.debug('Creating a summary of components in image...')
         for image in images:
@@ -323,7 +324,8 @@ def generate_verbose(is_summary, images):
 def generate_yaml(images):
     '''Generate a yaml report'''
     logger.debug('Creating YAML report...')
-    report = formats.disclaimer_yaml.format(version_info=general.get_git_rev_or_version())
+    report = formats.disclaimer_yaml.format(
+        version_info=general.get_git_rev_or_version())
     for image in images:
         report = report + content.print_yaml_report(image)
     return report
@@ -343,7 +345,7 @@ def check_docker_daemon():
         docker.from_env()
     except IOError as error:
         logger.error('Docker daemon is not running: %s',
-            error.output.decode('utf-8'))
+                     error.output.decode('utf-8'))
         sys.exit()
 
 

--- a/tests/test_class_package.py
+++ b/tests/test_class_package.py
@@ -84,6 +84,26 @@ class TestClassPackage(unittest.TestCase):
         p.version = '2.0'
         self.assertTrue(self.p2.is_equal(p))
 
+    def testFill(self):
+        p_dict = {'name': 'p1',
+                  'version': '1.0',
+                  'pkg_license': 'Apache 2.0'}
+        p = Package('p1')
+        p.fill(p_dict)
+        self.assertEqual(p.name, 'p1')
+        self.assertEqual(p.version, '1.0')
+        self.assertEqual(p.pkg_license, 'Apache 2.0')
+        self.assertFalse(p.copyright)
+        self.assertFalse(p.src_url)
+        self.assertEqual(len(p.origins.origins), 1)
+        self.assertEqual(p.origins.origins[0].origin_str, 'p1')
+        self.assertEqual(len(p.origins.origins[0].notices), 2)
+        self.assertEqual(p.origins.origins[0].notices[0].message,
+                         "No metadata for key: copyright")
+        self.assertEqual(p.origins.origins[0].notices[0].level, 'warning')
+        self.assertEqual(p.origins.origins[0].notices[1].message,
+                         "No metadata for key: src_url")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_class_package.py
+++ b/tests/test_class_package.py
@@ -17,6 +17,7 @@ class TestClassPackage(unittest.TestCase):
         self.p1 = Package('p1')
         self.p1.version = '1.0'
         self.p1.pkg_license = 'Apache 2.0'
+        self.p1.copyright = 'All Rights Reserved'
         self.p1.src_url = 'github.com'
 
         self.p2 = Package('p2')
@@ -30,6 +31,7 @@ class TestClassPackage(unittest.TestCase):
         self.assertFalse(self.p2.version)
         self.assertFalse(self.p2.src_url)
         self.assertFalse(self.p2.pkg_license)
+        self.assertFalse(self.p2.copyright)
 
     def testSetters(self):
         self.assertRaises(AttributeError, setattr, self.p2, 'name', 'y')
@@ -37,6 +39,8 @@ class TestClassPackage(unittest.TestCase):
         self.assertEqual(self.p2.version, '2.0')
         self.p2.pkg_license = 'Apache 2.0'
         self.assertEqual(self.p2.pkg_license, 'Apache 2.0')
+        self.p2.copyright = "All Rights Reserved"
+        self.assertEqual(self.p2.copyright, 'All Rights Reserved')
         self.p2.src_url = 'github.com'
         self.assertEqual(self.p2.src_url, 'github.com')
 
@@ -44,6 +48,7 @@ class TestClassPackage(unittest.TestCase):
         self.assertEqual(self.p1.name, 'p1')
         self.assertEqual(self.p1.version, '1.0')
         self.assertEqual(self.p1.pkg_license, 'Apache 2.0')
+        self.assertEqual(self.p1.copyright, 'All Rights Reserved')
         self.assertEqual(self.p1.src_url, 'github.com')
 
     def testToDict(self):
@@ -51,6 +56,7 @@ class TestClassPackage(unittest.TestCase):
         self.assertEqual(a_dict['name'], 'p1')
         self.assertEqual(a_dict['version'], '1.0')
         self.assertEqual(a_dict['pkg_license'], 'Apache 2.0')
+        self.assertEqual(a_dict['copyright'], 'All Rights Reserved')
         self.assertEqual(a_dict['src_url'], 'github.com')
         self.assertFalse(a_dict['origins'])
 


### PR DESCRIPTION
This PR resolves #245 

It contains changes to the Package object to include a 'copyright' property.
This also changes the listing in base.yml. It would report a warning for any
package manager listing that does not include a copyright listing. General
functionality is not affected.