### PR TITLE
classes: Modified SPDX template to match spec

### DIFF
--- a/tern/classes/templates/spdx.py
+++ b/tern/classes/templates/spdx.py
@@ -7,14 +7,16 @@
 from tern.classes.template import Template
 
 
-class SPDXTagValue(Template):
+class SPDX(Template):
     '''This is the SPDX Template class
     It provides mappings for the SPDX tag-value document format'''
 
     def package(self):
         return {'name': 'PackageName',
                 'version': 'PackageVersion',
-                'license': 'PackageLicenseDeclared'}
+                'pkg_license': 'PackageLicenseDeclared',
+                'copyright': 'PackageCopyrightText',
+                'download_url': 'PackageDownloadLocation'}
 
     def image_layer(self):
         return {'diff_id': 'PackageName',
@@ -23,4 +25,4 @@ class SPDXTagValue(Template):
     def image(self):
         return {'name': 'PackageName',
                 'tag': 'PackageVersion',
-                'id': 'PackageChecksum'}
+                'repotag': 'PackageDownloadLocation'}


### PR DESCRIPTION
- Changed the class name to SPDX as this is just a matching of
property names to what the SPDX spec wants
- Added the copyright and download_url mapping for the package
template
- Added the repotag mapping for the image template

There are some missing mandatory tags which either don't apply
to OCI's image specification or there is no way to get the values
for those properties

- Image layers don't have individual licenses and copyright text
- Image layers' download location is the same as the higher level
image
- An image has a digest but is referenced as a directed acyclical
graph. OCI considers the image digest to be the hash
of the index.json file that describes the image and not the content
of the image itself. This is like git shas in the sense that the
digest is of differences not the files themselves. So we shall
not use a PackageChecksum

Signed-off-by: Nisha K <nishak@vmware.com>