### PR TITLE
Add test for get_package_id in Package class

### DIFF
--- a/tests/test_class_package.py
+++ b/tests/test_class_package.py
@@ -112,6 +112,9 @@ class TestClassPackage(unittest.TestCase):
         self.assertEqual(p.origins.origins[0].notices[2].message,
                          "No metadata for key: download_url")
 
+    def testGetPackageId(self):
+        self.assertEqual(self.p1.get_package_id(), 'p1.1.0')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Add a test to verify that the get_package_id
method in the Package class returns a proper
string containing the package name.version.

Resolves: #251
See also: #241

Signed-off-by: Rose Judge <rose.harber@gmail.com>