### PR TITLE
Rename 'src_url' to 'proj_url'

### DIFF
--- a/docs/adding-to-command-library.md
+++ b/docs/adding-to-command-library.md
@@ -145,7 +145,7 @@ packages with a unique name. In this case, there is only the default listing:
           1:
             container:
               - "dpkg -l {package} | awk 'NR>5 {print $3}'"
-      src_url:
+      proj_url:
         invoke:
           1:
             container:
@@ -273,7 +273,7 @@ $ export PYTHONPATH=`pwd`
 ```
 3. Run verify_invoke with the following flags
 ```
-$ python tools/verify_invoke.py --container test --keys snippets <command> packages <version/license/src_url> --shell '/usr/bin/bash' --package <package name>
+$ python tools/verify_invoke.py --container test --keys snippets <command> packages <version/license/proj_url> --shell '/usr/bin/bash' --package <package name>
 ```
 
 This should give you a result that looks something like this:
@@ -286,7 +286,7 @@ Number of elements: 1
 
 For snippets.yml the first key is 'snippets'. If you look up tyum > packages in
 snippets.yml, you should see a list of dictionaries. Go ahead and give the required
-attribute (version, license or src_url) as the next key. The listing containing the
+attribute (version, license or proj_url) as the next key. The listing containing the
 'invoke' key should look something like this:
 ```
       version:

--- a/tern/classes/package.py
+++ b/tern/classes/package.py
@@ -16,7 +16,7 @@ class Package:
         version: package version
         pkg_license: package license that is declared
         copyright: copyright text
-        src_url: package source url
+        proj_url: package source url
         download_url: package download url
         origins: a list of NoticeOrigin objects
 
@@ -29,7 +29,7 @@ class Package:
         self.__version = ''
         self.__pkg_license = ''
         self.__copyright = ''
-        self.__src_url = ''
+        self.__proj_url = ''
         self.__download_url = ''
         self.__origins = Origins()
 
@@ -62,12 +62,12 @@ class Package:
         self.__copyright = text
 
     @property
-    def src_url(self):
-        return self.__src_url
+    def proj_url(self):
+        return self.__proj_url
 
-    @src_url.setter
-    def src_url(self, src_url):
-        self.__src_url = src_url
+    @proj_url.setter
+    def proj_url(self, proj_url):
+        self.__proj_url = proj_url
 
     @property
     def download_url(self):
@@ -123,7 +123,7 @@ class Package:
             version: <version>
             pkg_license: <package license string>
             copyright: <package copyright text>
-            src_url: <source url>
+            proj_url: <project url>
         the way to use this method is to instantiate the class with the
         name and then give it a package dictionary to fill in the rest
         return true if package name is the same as the one used to instantiate

--- a/tern/command_lib/base.yml
+++ b/tern/command_lib/base.yml
@@ -43,7 +43,7 @@ tdnf:
           - 'pkgs=`tdnf list installed | cut -f1 -d"."`'
           - 'for p in $pkgs; do tdnf info $p | head -10 | tail -1 | cut -f2 -d":" | xargs; done'
     delimiter: "\n"
-  src_urls:
+  proj_urls:
     invoke:
       1:
         container:
@@ -80,7 +80,7 @@ dpkg:
           - "pkgs=`dpkg --get-selections | cut -f1 -d':' | awk '{print $1}'`"
           - "for p in $pkgs; do cat /usr/share/doc/$p/copyright; echo LICF; done"
     delimiter: 'LICF'
-  src_urls: {}
+  proj_urls: {}
 
 # apk ---------------------------------------------------------------------------------------------------------
 apk:
@@ -109,7 +109,7 @@ apk:
           - 'pkgs=`apk info 2>/dev/null`'
           - 'for p in $pkgs; do apk -a info $p 2>/dev/null | tail -2 | head -1; done'
     delimiter: "\n"
-  src_urls:
+  proj_urls:
     invoke:
       1:
         container:
@@ -140,7 +140,7 @@ pacman:
         container:
           - 'pacman -Qi 2>/dev/null | sed -n "/Licenses/p" | cut -d ":" -f 2'
     delimiter: "\n"
-  src_urls:
+  proj_urls:
     invoke:
       1:
         container:
@@ -170,7 +170,7 @@ rpm:
         container:
           - 'rpm --query --all --queryformat "%{license}\n" 2>/dev/null'
     delimiter: "\n"
-  src_urls:
+  proj_urls:
     invoke:
       1:
         container:

--- a/tern/command_lib/command_lib.py
+++ b/tern/command_lib/command_lib.py
@@ -31,8 +31,8 @@ with open(os.path.abspath(base_file)) as f:
 with open(os.path.abspath(snippet_file)) as f:
     command_lib['snippets'] = yaml.safe_load(f)
 # list of package information keys that the command library can accomodate
-base_keys = {'names', 'versions', 'licenses', 'copyrights', 'src_urls', 'srcs'}
-package_keys = {'name', 'version', 'license', 'copyright', 'src_url', 'src'}
+base_keys = {'names', 'versions', 'licenses', 'copyrights', 'proj_urls', 'srcs'}
+package_keys = {'name', 'version', 'license', 'copyright', 'proj_url', 'src'}
 
 # global logger
 logger = logging.getLogger(constants.logger_name)

--- a/tern/common.py
+++ b/tern/common.py
@@ -108,7 +108,7 @@ def convert_to_pkg_dicts(pkg_dict):
                'version': 'versions',
                'pkg_license': 'licenses',
                'copyright': 'copyrights',
-               'src_url': 'src_urls'}
+               'proj_url': 'proj_urls'}
     pkg_list = []
     len_names = len(pkg_dict['names'])
     # make a list of keys that correspond with package property names
@@ -178,7 +178,7 @@ def fill_package_metadata(pkg_obj, pkg_listing, shell):
     '''Given a Package object and the Package listing from the command
     library, fill in the attribute value returned from looking up the
     data and methods of the package listing.
-    Fill out: version, license and src_url
+    Fill out: version, license and proj_url
     If there are errors, fill out notices'''
     # create a NoticeOrigin for the package
     origin_str = 'command_lib/snippets.yml'
@@ -210,14 +210,14 @@ def fill_package_metadata(pkg_obj, pkg_listing, shell):
     else:
         pkg_obj.origins.add_notice_to_origins(
             origin_str, Notice(listing_msg, 'warning'))
-    # src_urls
+    # proj_urls
     url_listing, listing_msg = command_lib.check_library_key(
-        pkg_listing, 'src_url')
+        pkg_listing, 'proj_url')
     if url_listing:
         url_list, invoke_msg = command_lib.get_pkg_attr_list(
             shell, url_listing, package_name=pkg_obj.name)
         if url_list:
-            pkg_obj.src_url = url_list[0]
+            pkg_obj.proj_url = url_list[0]
         else:
             pkg_obj.origins.add_notice_to_origins(
                 origin_str, Notice(invoke_msg, 'error'))

--- a/tern/report/content.py
+++ b/tern/report/content.py
@@ -57,7 +57,7 @@ def print_package_invoke(command_name):
         for pkg_dict in pkg_list:
             report = report + print_invoke_list(pkg_dict, 'version')
             report = report + print_invoke_list(pkg_dict, 'license')
-            report = report + print_invoke_list(pkg_dict, 'src_url')
+            report = report + print_invoke_list(pkg_dict, 'proj_url')
             report = report + print_invoke_list(pkg_dict, 'deps')
     return report
 
@@ -70,7 +70,7 @@ def print_package(pkg_obj, prefix):
     notes = notes + prefix + formats.package_version.format(
         package_version=pkg_obj.version)
     notes = notes + prefix + formats.package_url.format(
-        package_url=pkg_obj.src_url)
+        package_url=pkg_obj.proj_url)
     notes = notes + prefix + formats.package_license.format(
         package_license=pkg_obj.pkg_license)
     notes = notes + prefix + formats.package_copyright.format(

--- a/tern/report/errors.py
+++ b/tern/report/errors.py
@@ -18,7 +18,7 @@ no_version = '''No version for package {package_name}. Consider either ''' \
 no_license = '''No license for package {package_name}. Consider either ''' \
     '''entering the license manually or creating a script to retrieve it ''' \
     '''in the command library\n'''
-no_src_url = '''No source url for package {package_name}. Consider either ''' \
+no_proj_url = '''No project url for package {package_name}. Consider either ''' \
     '''entering the source url manually or creating a script to retrieve ''' \
     '''it in the command library\n'''
 env_dep_dockerfile = '''Docker build failed: {build_fail_msg} \n Since ''' \

--- a/tern/utils/cache.py
+++ b/tern/utils/cache.py
@@ -12,7 +12,7 @@ It is organized in this way:
            - name:
              version:
              license:
-             src_url:
+             proj_url:
         .....
 """
 

--- a/tests/test_class_package.py
+++ b/tests/test_class_package.py
@@ -18,7 +18,7 @@ class TestClassPackage(unittest.TestCase):
         self.p1.version = '1.0'
         self.p1.pkg_license = 'Apache 2.0'
         self.p1.copyright = 'All Rights Reserved'
-        self.p1.src_url = 'github.com'
+        self.p1.proj_url = 'github.com'
         self.p1.download_url = 'https://github.com'
 
         self.p2 = Package('p2')
@@ -30,7 +30,7 @@ class TestClassPackage(unittest.TestCase):
     def testInstance(self):
         self.assertEqual(self.p2.name, 'p2')
         self.assertFalse(self.p2.version)
-        self.assertFalse(self.p2.src_url)
+        self.assertFalse(self.p2.proj_url)
         self.assertFalse(self.p2.pkg_license)
         self.assertFalse(self.p2.copyright)
         self.assertFalse(self.p2.download_url)
@@ -43,8 +43,8 @@ class TestClassPackage(unittest.TestCase):
         self.assertEqual(self.p2.pkg_license, 'Apache 2.0')
         self.p2.copyright = "All Rights Reserved"
         self.assertEqual(self.p2.copyright, 'All Rights Reserved')
-        self.p2.src_url = 'github.com'
-        self.assertEqual(self.p2.src_url, 'github.com')
+        self.p2.proj_url = 'github.com'
+        self.assertEqual(self.p2.proj_url, 'github.com')
         self.p2.download_url = 'https://github.com'
         self.assertEqual(self.p2.download_url, 'https://github.com')
 
@@ -53,7 +53,7 @@ class TestClassPackage(unittest.TestCase):
         self.assertEqual(self.p1.version, '1.0')
         self.assertEqual(self.p1.pkg_license, 'Apache 2.0')
         self.assertEqual(self.p1.copyright, 'All Rights Reserved')
-        self.assertEqual(self.p1.src_url, 'github.com')
+        self.assertEqual(self.p1.proj_url, 'github.com')
         self.assertEqual(self.p1.download_url, 'https://github.com')
 
     def testToDict(self):
@@ -62,7 +62,7 @@ class TestClassPackage(unittest.TestCase):
         self.assertEqual(a_dict['version'], '1.0')
         self.assertEqual(a_dict['pkg_license'], 'Apache 2.0')
         self.assertEqual(a_dict['copyright'], 'All Rights Reserved')
-        self.assertEqual(a_dict['src_url'], 'github.com')
+        self.assertEqual(a_dict['proj_url'], 'github.com')
         self.assertEqual(a_dict['download_url'], 'https://github.com')
         self.assertFalse(a_dict['origins'])
 
@@ -82,10 +82,10 @@ class TestClassPackage(unittest.TestCase):
         p = Package('p2')
         p.pkg_license = 'Testpkg_license'
         p.version = '1.0'
-        p.src_url = 'TestUrl'
+        p.proj_url = 'TestUrl'
         self.p2.pkg_license = 'Testpkg_license'
         self.p2.version = '2.0'
-        self.p2.src_url = 'TestUrl'
+        self.p2.proj_url = 'TestUrl'
         self.assertFalse(self.p2.is_equal(p))
         p.version = '2.0'
         self.assertTrue(self.p2.is_equal(p))
@@ -100,7 +100,7 @@ class TestClassPackage(unittest.TestCase):
         self.assertEqual(p.version, '1.0')
         self.assertEqual(p.pkg_license, 'Apache 2.0')
         self.assertFalse(p.copyright)
-        self.assertFalse(p.src_url)
+        self.assertFalse(p.proj_url)
         self.assertEqual(len(p.origins.origins), 1)
         self.assertEqual(p.origins.origins[0].origin_str, 'p1')
         self.assertEqual(len(p.origins.origins[0].notices), 3)
@@ -108,7 +108,7 @@ class TestClassPackage(unittest.TestCase):
                          "No metadata for key: copyright")
         self.assertEqual(p.origins.origins[0].notices[0].level, 'warning')
         self.assertEqual(p.origins.origins[0].notices[1].message,
-                         "No metadata for key: src_url")
+                         "No metadata for key: proj_url")
         self.assertEqual(p.origins.origins[0].notices[2].message,
                          "No metadata for key: download_url")
 

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -47,7 +47,7 @@ class TestTemplate2(Template):
         mapping = {'name': 'package.name',
                    'version': 'package.version',
                    'pkg_license': 'package.license',
-                   'src_url': 'package.url'}
+                   'proj_url': 'package.url'}
         # we update the mapping with another defined mapping
         mapping.update(self.origins())
         return mapping


### PR DESCRIPTION
The term src_url is misleading as the scripts do not
retrieve the source url. Replace all instances of
src_url with proj_url to reflect what gets retrieved.

Resolves: #254

Signed-off-by: Rose Judge <rose.harber@gmail.com>