### PR TITLE
main: Add argument for format type

### DIFF
--- a/tern/__main__.py
+++ b/tern/__main__.py
@@ -10,6 +10,7 @@ Tern executable
 
 
 import argparse
+import importlib
 import logging
 import os
 
@@ -35,6 +36,16 @@ log_handler.setFormatter(formatter)
 console.setFormatter(formatter)
 
 logger.addHandler(log_handler)
+
+
+def check_format_type(format_type):
+    '''Check if the format type is supported'''
+    import_string = 'tern.report.{}.generator'.format(format_type)
+    try:
+        importlib.import_module(import_string)
+    except ModuleNotFoundError:
+        raise argparse.ArgumentTypeError('Invalid report formatting type')
+    return format_type
 
 
 def do_main(args):
@@ -97,6 +108,11 @@ def main():
     parser_report.add_argument('-s', '--summary', action='store_true',
                                help="Summarize the report as a list of"
                                " packages with associated information")
+    parser_report.add_argument('-m', '--format', metavar='REPORT_MODULE',
+                               type=check_format_type,
+                               help="Format the report using one of the "
+                               "available formats: "
+                               "spdxtagvalue")
     parser_report.add_argument('-y', '--yaml', action='store_true',
                                help="Create a report in yaml format")
     parser_report.add_argument('-j', '--json', action='store_true',


### PR DESCRIPTION
Added a command line argument under the report subcommand for
report format type. This takes a string value and checks to
see if it is importable. If it is not, then the format is not
supported.

Resolves #260

Signed-off-by: Nisha K <nishak@vmware.com>