### PR TITLE
Tighten SPDX document reporting

### DIFF
--- a/tern/classes/docker_image.py
+++ b/tern/classes/docker_image.py
@@ -168,3 +168,8 @@ class DockerImage(Image):
             raise
         except IOError:  # pylint: disable=try-except-raise
             raise
+
+    def get_download_location(self):
+        '''A docker image's download location is in the repotags. We will
+        return a string of repotags joined by a hyphen -'''
+        return '-'.join(self.repotags)

--- a/tern/classes/image.py
+++ b/tern/classes/image.py
@@ -141,9 +141,14 @@ class Image:
         '''Some reports like SPDX want a unique name for the full image
         and this is currently not supported by any image tool. So using
         a combination of image id, name and tag instead'''
-        name = self.image_id
+        name = self.image_id[:10]
         if self.name:
             name = name + '-{}'.format(self.name)
         if self.tag:
             name = name + '-{}'.format(self.tag)
         return name
+
+    def get_download_location(self):
+        '''Return the registry information from where the image came from.
+        Currently, the image's metadata doesn't have this information'''
+        pass

--- a/tern/classes/templates/spdx.py
+++ b/tern/classes/templates/spdx.py
@@ -19,8 +19,10 @@ class SPDX(Template):
                 'download_url': 'PackageDownloadLocation'}
 
     def image_layer(self):
+        # TODO: hash_type should be added in the class property
+        # not hardcoded here
         return {'diff_id': 'PackageName',
-                'fs_hash': 'PackageChecksum'}
+                'fs_hash': 'PackageChecksum: SHA256'}
 
     def image(self):
         return {'name': 'PackageName',

--- a/tern/report/spdxtagvalue/generator.py
+++ b/tern/report/spdxtagvalue/generator.py
@@ -180,7 +180,7 @@ def generate(image_obj_list):
     # The image's PackageDownloadLocation is from a container registry
     # This includes all the layers but the packages' download location
     # is unknown if the download_url is blank
-    registry_repotag = image_obj.repotag if hasattr(
+    registry_repotag = image_obj.get_download_location() if hasattr(
         image_obj, 'repotag') else 'NOASSERTION'
 
     # first part is the document tag-value


### PR DESCRIPTION
- Added a method get_download_location to Image and DockerImage
classes. The DockerImage method is implemented.
- Modified the get_human_readable_id in Image class to use a shortened
checksum to make the report more readable.
- Added a 'SHA256' string to satisfy SPDX checksum spec. Also added a
TODO to have this an actual property in the classes.
- Used the get_download_location method for the value of the registry
repotag. With Docker version 18.09, this is the same as the name and
tag. There is currently no information about the registry the image
was pulled from in the metadata.

Signed-off-by: Nisha K <nishak@vmware.com>