### PR TITLE
report: spdxtagvalue: Generate license reference

### DIFF
--- a/tern/report/spdxtagvalue/formats.py
+++ b/tern/report/spdxtagvalue/formats.py
@@ -29,3 +29,7 @@ package_comment = 'PackageComment: <text>{comment}</text>'
 # Relationship strings
 contains = 'Relationship: {outer} CONTAINS {inner}'
 prereq = 'Relationship: {after} HAS_PREREQUISITE {before}'
+
+# License Reference Information
+license_id = 'LicenseID: {license_ref}'
+extracted_text = 'ExtractedText: <text>Original license: {orig_license}</text>'


### PR DESCRIPTION
For licenses with non-spdx license formats, attach a document block
referring to the LicenseRef with some information about the license.

In this case, we just add a string that says
'Original License: <the license that the Package object has>'

For this to work, we needed a global licenses_found list and a
function that will split up the license string in the Package object,
check to see if each of those are in the licenses_found list and
if not, then add it.

Then at then end, take each of those licenses in the license_found
list and make a block of text with the required strings.

At this point, the SPDX validator seems to be happy with the output

Signed-off-by: Nisha K <nishak@vmware.com>