### PR TITLE
Cleanup and add missing SPDX copyright headers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
 FROM photon:3.0
 
 # install system dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,10 @@
-# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 #
 # Please only add direct dependencies here, i.e., do not update with the
 # output of `pip freeze`.  When updating dependency versions, have the
 # transitive dependencies listed make it more difficult to figure out
 # what should be updated.
-#
 
 PyYAML==5.1
 docker==4.0.1

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
 from setuptools import setup, find_packages
 
 from tern import Version

--- a/tern/__init__.py
+++ b/tern/__init__.py
@@ -1,2 +1,6 @@
 # -*- coding: utf-8 -*-
+#
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
 Version = "0.4.0"

--- a/tern/__main__.py
+++ b/tern/__main__.py
@@ -3,7 +3,7 @@
 #
 # Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
-#
+
 """
 Tern executable
 """

--- a/tern/classes/__init__.py
+++ b/tern/classes/__init__.py
@@ -1,1 +1,4 @@
 # -*- coding: utf-8 -*-
+#
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause

--- a/tern/classes/command.py
+++ b/tern/classes/command.py
@@ -2,7 +2,6 @@
 #
 # Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
-#
 
 from tern.utils.general import parse_command
 

--- a/tern/classes/docker_image.py
+++ b/tern/classes/docker_image.py
@@ -2,7 +2,6 @@
 #
 # Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
-#
 
 import json
 import os

--- a/tern/classes/image.py
+++ b/tern/classes/image.py
@@ -2,7 +2,6 @@
 #
 # Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
-#
 
 from tern.classes.origins import Origins
 from tern.utils.general import prop_names

--- a/tern/classes/image_layer.py
+++ b/tern/classes/image_layer.py
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
-#
+
 import os
 
 from tern.classes.package import Package

--- a/tern/classes/notice.py
+++ b/tern/classes/notice.py
@@ -2,7 +2,6 @@
 #
 # Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
-#
 
 from tern.utils.general import prop_names
 

--- a/tern/classes/notice_origin.py
+++ b/tern/classes/notice_origin.py
@@ -2,7 +2,6 @@
 #
 # Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
-#
 
 from tern.report import formats
 from tern.utils.general import prop_names

--- a/tern/classes/origins.py
+++ b/tern/classes/origins.py
@@ -2,7 +2,6 @@
 #
 # Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
-#
 
 from tern.classes.notice_origin import NoticeOrigin
 

--- a/tern/classes/package.py
+++ b/tern/classes/package.py
@@ -2,7 +2,6 @@
 #
 # Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
-#
 
 from tern.classes.notice import Notice
 from tern.classes.origins import Origins

--- a/tern/classes/template.py
+++ b/tern/classes/template.py
@@ -2,7 +2,6 @@
 #
 # Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
-#
 
 from abc import ABCMeta
 from abc import abstractmethod

--- a/tern/classes/templates/__init__.py
+++ b/tern/classes/templates/__init__.py
@@ -1,1 +1,4 @@
 # -*- coding: utf-8 -*-
+#
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause

--- a/tern/classes/templates/spdx.py
+++ b/tern/classes/templates/spdx.py
@@ -2,7 +2,6 @@
 #
 # Copyright (c) 2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
-#
 
 from tern.classes.template import Template
 

--- a/tern/command_lib/__init__.py
+++ b/tern/command_lib/__init__.py
@@ -1,1 +1,4 @@
 # -*- coding: utf-8 -*-
+#
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause

--- a/tern/command_lib/base.yml
+++ b/tern/command_lib/base.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 #
 # Known package listings for base images

--- a/tern/command_lib/command_lib.py
+++ b/tern/command_lib/command_lib.py
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
-#
+
 """
 Invoking commands in the command library
 """

--- a/tern/command_lib/snippets.yml
+++ b/tern/command_lib/snippets.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 #
 # general commands to be invoked when retrieving package information

--- a/tern/common.py
+++ b/tern/common.py
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
-#
+
 '''
 Common functions
 '''

--- a/tern/docker_helpers.py
+++ b/tern/docker_helpers.py
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
-#
+
 """
 Docker specific functions - used when trying to retrieve packages when
 given a Dockerfile

--- a/tern/report/__init__.py
+++ b/tern/report/__init__.py
@@ -1,1 +1,4 @@
 # -*- coding: utf-8 -*-
+#
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause

--- a/tern/report/content.py
+++ b/tern/report/content.py
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
-#
+
 """
 Functions to generate content for the report
 """

--- a/tern/report/errors.py
+++ b/tern/report/errors.py
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
-#
+
 """
 Error messages
 """

--- a/tern/report/formats.py
+++ b/tern/report/formats.py
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
-#
+
 """
 Report formatting for different types of reports and report content
 """

--- a/tern/report/report.py
+++ b/tern/report/report.py
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
-#
+
 """
 Create a report
 """

--- a/tern/report/spdxtagvalue/__init__.py
+++ b/tern/report/spdxtagvalue/__init__.py
@@ -2,4 +2,3 @@
 #
 # Copyright (c) 2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
-#

--- a/tern/report/spdxtagvalue/formats.py
+++ b/tern/report/spdxtagvalue/formats.py
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
-#
+
 """
 SPDX document formatting
 """

--- a/tern/report/spdxtagvalue/generator.py
+++ b/tern/report/spdxtagvalue/generator.py
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
-#
+
 """
 SPDX document generator
 """

--- a/tern/scripts/debian/apt_get_sources.sh
+++ b/tern/scripts/debian/apt_get_sources.sh
@@ -1,4 +1,4 @@
-# Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
 #!/bin/bash

--- a/tern/scripts/debian/jessie/sources.list
+++ b/tern/scripts/debian/jessie/sources.list
@@ -1,3 +1,6 @@
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
 deb http://deb.debian.org/debian jessie main
 deb http://deb.debian.org/debian jessie-updates main
 deb http://security.debian.org jessie/updates main

--- a/tern/tools/fs_hash.sh
+++ b/tern/tools/fs_hash.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2018-2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 #
 # Given a file path, create a list of file stats and their sha256sums

--- a/tern/tools/verify_invoke.py
+++ b/tern/tools/verify_invoke.py
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
-#
+
 """
 Test script for running commands in a chroot environment to check if the
 results produced are expected

--- a/tern/utils/__init__.py
+++ b/tern/utils/__init__.py
@@ -1,1 +1,4 @@
 # -*- coding: utf-8 -*-
+#
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause

--- a/tern/utils/cache.py
+++ b/tern/utils/cache.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, 2019 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
-#
+
 """
 Docker layer cache related modules
 The cache is currently stored in a yaml file called cache.yml

--- a/tern/utils/constants.py
+++ b/tern/utils/constants.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, 2019 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
-#
 
 '''
 Constants

--- a/tern/utils/container.py
+++ b/tern/utils/container.py
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
-#
+
 """
 Docker container operations
 """

--- a/tern/utils/dockerfile.py
+++ b/tern/utils/dockerfile.py
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
-#
+
 """
 Dockerfile parser and information retrieval
 """

--- a/tern/utils/general.py
+++ b/tern/utils/general.py
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
-#
+
 import os
 import random
 import re

--- a/tern/utils/metadata.py
+++ b/tern/utils/metadata.py
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
-#
+
 """
 Container metadata operations
 """

--- a/tern/utils/rootfs.py
+++ b/tern/utils/rootfs.py
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
-#
+
 """
 Operations to mount container filesystems and run commands against them
 """

--- a/tests/test_class_command.py
+++ b/tests/test_class_command.py
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
-#
+
 import unittest
 
 from classes.command import Command

--- a/tests/test_class_docker_image.py
+++ b/tests/test_class_docker_image.py
@@ -2,7 +2,6 @@
 #
 # Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
-#
 
 import unittest
 import subprocess  # nosec

--- a/tests/test_class_image.py
+++ b/tests/test_class_image.py
@@ -2,7 +2,6 @@
 #
 # Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
-#
 
 import unittest
 

--- a/tests/test_class_image_layer.py
+++ b/tests/test_class_image_layer.py
@@ -2,7 +2,6 @@
 #
 # Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
-#
 
 import unittest
 

--- a/tests/test_class_notice.py
+++ b/tests/test_class_notice.py
@@ -2,7 +2,6 @@
 #
 # Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
-#
 
 import unittest
 

--- a/tests/test_class_notice_origin.py
+++ b/tests/test_class_notice_origin.py
@@ -2,7 +2,6 @@
 #
 # Copyright (c) 2018-2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
-#
 
 import unittest
 

--- a/tests/test_class_origins.py
+++ b/tests/test_class_origins.py
@@ -1,7 +1,5 @@
-#
 # Copyright (c) 2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
-#
 
 import unittest
 

--- a/tests/test_class_package.py
+++ b/tests/test_class_package.py
@@ -2,7 +2,6 @@
 #
 # Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
-#
 
 import unittest
 

--- a/tests/test_class_template.py
+++ b/tests/test_class_template.py
@@ -2,7 +2,6 @@
 #
 # Copyright (c) 2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
-#
 
 import unittest
 

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
-#
+
 """
 Objects to use for testing
 """

--- a/tests/test_util_commands.py
+++ b/tests/test_util_commands.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
-#
 
 import unittest
 

--- a/tests/test_util_metadata.py
+++ b/tests/test_util_metadata.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
-#
 
 import unittest
 

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,6 +1,9 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
-
+#
+# Copyright (c) 2018-2019 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+#
 # All Vagrant configuration is done below. The "2" in Vagrant.configure
 # configures the configuration version (we support older styles for
 # backwards compatibility). Please don't change it unless you know what

--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-
+#
+# Copyright (c) 2018-2019 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
 
 # Update the Ubuntu repositories
 sudo apt-get update


### PR DESCRIPTION
This commit made 3 primary changes:
  1) Added missing SPDX copyright headers to any files
     where they were missing.
  2) Cleaned up a few copyright dates that were incorrect.
  3) Cleaned up empty comments at the end of copyright
     headers.

Resolves: #210

Signed-off-by: Rose Judge <rjudge@vmware.com>