### PR TITLE
Add Bandit to linting tools

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,7 @@ jobs:
       - run: pip install -r dev-requirements.txt
       - run: pip install .
       - run: prospector .
+      - run: bandit -r .
   # full functional test for photonOS
   funcphoton:
     executor: ubuntu1604

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,9 @@ You may have already cloned the project and started working on it. If you're rea
 ### After making changes
 1. Run prospector from the project's root directory `prospector .`
 2. Fix any issues prospector brings up.
-3. Run `pip install .`. Don't worry about the already satisfied dependencies.
+3. Run bandit from the project's root directory `bandit -r .`
+4. Fix any issues bandit brings up.
+5. Run `pip uninstall tern`, then run `pip install .` to install tern with your changes. Don't worry about the already satisfied dependencies.
 4. Test your changes.
 
 ## Coding Style

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,3 +6,5 @@
 
 # For development work, pull in dev support utilities
 prospector==1.1.6.2
+# For security linting, use Bandit
+bandit==1.6.0


### PR DESCRIPTION
Bandit is a tool to lint for secure coding. It is used by the
GitHub app Precaution. Currently, Precaution prevents CircleCI
jobs from building. This is a reasonable workaround of that issue
without compromising security checks.

- Added bandit to dev-requirements.txt
- Added documentation on running bandit when doing development
- Added bandit to the CircleCI linting job

Signed-off-by: Nisha K <nishak@vmware.com>