### PR TITLE
Add commit message linting script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,13 @@ jobs:
       - run: pip install .
       - run: prospector .
       - run: bandit -r .
+  commit_check:
+    executor: ubuntu1604
+    # Steps to run commit message linting
+    steps:
+      - setup
+      - run: pip install -r dev-requirements.txt
+      - run: python tests/test_commit_message.py
   # full functional test for photonOS
   funcphoton:
     executor: ubuntu1604
@@ -41,3 +48,4 @@ workflows:
   PRs:
     jobs:
       - linting
+      - commit_check

--- a/tests/test_commit_message.py
+++ b/tests/test_commit_message.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+from git import Repo
+import os
+import re
+import sys
+
+check = True
+
+# we are currently in the 'tern' repo
+repo = Repo(os.getcwd())
+commitmsg = repo.head.commit.message
+
+message = re.split('\n\n|\r', commitmsg, 1)
+body = re.split('\n|\r', message[1])
+
+# Git does not allow for empty titles
+# Check that commit message has 3 elements
+# for title, body and signed-off line
+if len(re.split('\n\n|\r', commitmsg)) <= 2:
+    print("Commit message should have a body.")
+    check = False
+
+# Check subject length
+if len(message[0]) > 54:
+    print("Commit message subject should be 50 characters or less.")
+    check = False
+
+# Check body length 
+for i in range(len(body)):
+    if len(body[i]) > 72:
+        print("Line {} of the body may not exceed 72 characters.".format(i+1))
+        check = False
+
+if not check:
+    sys.exit(1)


### PR DESCRIPTION
This commit makes the following changes:
  1) Adds test_commit_message.py file which contains code to check the
     presence of a commit subject and body. The test file also checks to
     make sure that the length of each line adheres to the tern
     guidelines of less than 50 characters for the subject and 72
     characters for the body.

  2) Adds the commit message linting workflow to circleci config.yml

Resolves #301 

Signed-off-by: Rose Judge <rjudge@vmware.com>