### PR TITLE
Separate bandit and prospector linting in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,15 @@ jobs:
       - run: pip install -r dev-requirements.txt
       - run: pip install .
       - run: prospector .
+  # security linting using Bandit
+  security:
+    executor: ubuntu1604
+    # steps to run Bandit
+    steps:
+      - setup
+      - run: pip install -r dev-requirements.txt
       - run: bandit -r .
+  # linting for PR commit messages
   commit_check:
     executor: ubuntu1604
     # Steps to run commit message linting
@@ -49,3 +57,4 @@ workflows:
     jobs:
       - linting
       - commit_check
+      - security


### PR DESCRIPTION
This commit makes the following changes:

  1) Creates a new workflow for Bandit to run in circleci.
  2) Removes Bandit from running as part of the prospector work flow
  3) Adds documentation related to a previous commit (0cba95a) so
     that comments are consistent in this file.

Resolves #303

Signed-off-by: Rose Judge <rjudge@vmware.com>