### PR TITLE
fix: ci: Check for no commits

### DIFF
--- a/ci/test_commit_message.py
+++ b/ci/test_commit_message.py
@@ -11,8 +11,9 @@ import sys
 # This script is written to be used with circleci and
 # is not meant to be run locally
 
+
 def lint_commit(commit_id):
-    """Given a commit ID, determine if the 
+    """Given a commit ID, determine if the
     commit message complies with the tern guidelines. If
     it does not comply, output the offending commit and
     specify the reason for failure."""
@@ -30,18 +31,22 @@ def lint_commit(commit_id):
 
     # Check 2: Subject length is less than about 50
     if len(re.split('\n\n', message)[0]) > 54:
-        print("The subject of commit {} should be 50 characters or less.".format(sha_short))
+        print(
+            "The subject of commit {} should be 50 characters or less.".format(
+                sha_short))
         check = False
 
-    #Check 3: Each line of the body is less than 72
+    # Check 3: Each line of the body is less than 72
     body = re.split('\n\n|\r', message, 1)[1]
     for i in range(len(body)):
         if len(body[i]) > 72:
-            print("Line {0} of commit {1} exceeds 72 characters.".format(i+1, sha_short))
+            print("Line {0} of commit {1} exceeds 72 characters.".format(
+                i+1, sha_short))
             check = False
 
     if not check:
         sys.exit(1)
+
 
 if __name__ == '__main__':
     # Get the list of commits and loop through them,
@@ -51,10 +56,12 @@ if __name__ == '__main__':
     repo = Repo(os.getcwd())
     repo.git.remote('add', 'upstream', 'git@github.com:vmware/tern.git')
     repo.git.fetch('upstream')
-    # Will give list of commit IDs differentiating HEAD and master
-    commits = repo.git.rev_list('HEAD', '^upstream/master').split('\n')
-
-    for commit_id in commits:
-        lint_commit(commit_id)
-
-
+    # Will return commit IDs differentiating HEAD and master
+    commitstr = repo.git.rev_list('HEAD', '^upstream/master')
+    # If we are on the main project's master branch then there will be no
+    # difference and the result will be an empty string
+    # So we will not proceed if there is no difference
+    if commitstr:
+        commits = commitstr.split('\n')
+        for commit_id in commits:
+            lint_commit(commit_id)


### PR DESCRIPTION
CircleCI will trigger on the master branch once the pull request is
merged. In this scenario there is no difference between what is on
master and what is on the upstream's master because they are one and
the same. So the result of git rev-list is an empty string. In this
case we do nothing.

Signed-off-by: Nisha K <nishak@vmware.com>