### PR TITLE
Remove 'D' from utf header in test_files_touched.py

### DIFF
--- a/ci/test_files_touched.py
+++ b/ci/test_files_touched.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-D
+# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause


### PR DESCRIPTION
Remove the 'D' that somehow snuck into the first line of the file :)

Signed-off-by: Rose Judge <rjudge@vmware.com>