### PR TITLE
ci: Don't run prospector for .md file changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,11 @@ jobs:
       - setup
       - run: pip install -r dev-requirements.txt
       - run: pip install .
-      - run: prospector .
+      - run: python ci/evaluate_docs.py
+      - run:
+         name: Prospector
+         when: on_success
+         command: prospector .
   # security linting using Bandit
   security:
     executor: ubuntu1604

--- a/ci/evaluate_docs.py
+++ b/ci/evaluate_docs.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+from git import Repo
+import os
+import sys
+
+
+# This script is designed to be run with circleci.
+# This script should pass if we need to run Bandit and Prospector,
+# which means that there are files other than *.md files being changed.
+# If only *.md files are changed, we don't need to run Bandit
+# or Prospector and the script will fail.
+
+# Assume that all files are *.md until proven otherwise 
+docs_only = True
+
+
+repo = Repo(os.getcwd())
+repo.git.remote('add', 'upstream', 'git@github.com:vmware/tern.git')
+repo.git.fetch('upstream')
+
+hcommit = repo.head.commit
+diff = hcommit.diff('upstream/master')
+
+changes=[]
+for d in diff:
+    # Get the list of strings for changed files
+    changes.append(d.b_path)
+
+# check that changes has entries
+if not changes:
+    print('No changes to run tests for.')
+    sys.ext(1)
+
+for change in changes:
+    if change[-3:] != '.md': 
+        docs_only = False
+        break
+
+if docs_only:
+    sys.exit(1)
+else:
+    sys.exit(0)


### PR DESCRIPTION
Currently Prospector runs for all pull requests but in reality, we only
need to run Prospector on changes in non-*.md files.

This commit introduces the following changes:

  1) Adds evaluate_docs.py to the 'ci' directory. This script will fail
     if the only changes made were to *.md files.
  2) Modifies .circleci/config.yml to only run Prospector if the
     evaluate_docs.py test passes.

Signed-off-by: Rose Judge <rjudge@vmware.com>