### PR TITLE
ci: Fix exit statement for change based tests

### DIFF
--- a/ci/test_files_touched.py
+++ b/ci/test_files_touched.py
@@ -26,8 +26,8 @@ for d in diff:
 
 # check that changes has entries
 if not changes:
-    print('No changes to run tests for.')
-    sys.ext(1)
+    printf('No changes to run tests for.')
+    sys.exit(0)
 
 test_suite = {
     # dev-requirements.txt


### PR DESCRIPTION
In the scenario where there are no changes to run tests for, the
script should exit with a success, not a failure. This scenario
occurs when this test is run on the working branch once the PR is
merged.

Signed-off-by: Nisha K <nishak@vmware.com>