### PR TITLE
ci: Fix another exit and print error

### DIFF
--- a/ci/evaluate_docs.py
+++ b/ci/evaluate_docs.py
@@ -14,7 +14,7 @@ import sys
 # If only *.md files are changed, we don't need to run Bandit
 # or Prospector and the script will fail.
 
-# Assume that all files are *.md until proven otherwise 
+# Assume that all files are *.md until proven otherwise
 docs_only = True
 
 
@@ -33,10 +33,10 @@ for d in diff:
 # check that changes has entries
 if not changes:
     print('No changes to run tests for.')
-    sys.ext(1)
+    sys.exit(0)
 
 for change in changes:
-    if change[-3:] != '.md': 
+    if change[-3:] != '.md':
         docs_only = False
         break
 

--- a/ci/test_files_touched.py
+++ b/ci/test_files_touched.py
@@ -26,7 +26,7 @@ for d in diff:
 
 # check that changes has entries
 if not changes:
-    printf('No changes to run tests for.')
+    print('No changes to run tests for.')
     sys.exit(0)
 
 test_suite = {


### PR DESCRIPTION
- Fix the exit statement in evaluate_docs: if there are no changes
there is nothing to run tests for, so exit with success
- Remove trailing white spaces
- Fix the printf statement that got introduced back due to bad
rebase

Signed-off-by: Nisha K <nishak@vmware.com>