### PR TITLE
ci: Make test_suite a dictionary of lists

### DIFF
--- a/ci/test_files_touched.py
+++ b/ci/test_files_touched.py
@@ -31,33 +31,35 @@ if not changes:
 
 test_suite = {
     # dev-requirements.txt
-    re.compile('dev-requirements.txt'): 'tern -l report -i photon:3.0',
+    re.compile('dev-requirements.txt'): ['tern -l report -i photon:3.0'],
     # requirements.txt
-    re.compile('requirements.txt'): 'tern -l report -i photon:3.0',
+    re.compile('requirements.txt'): ['tern -l report -i photon:3.0'],
     # Dockerfile
     re.compile('Dockerfile'): [
         'docker build -t ternd .',
         './docker_run.sh workdir ternd "report -i golang:alpine"'],
     # Files under tern directory
     re.compile('tern/__init__.py|tern/__main__.py'):
-    'tern -l report -i golang:alpine',
+    ['tern -l report -i golang:alpine'],
     # tern/classes
     re.compile('tern/classes/command.py'):
-    'python tests/test_class_command.py',
+    ['python tests/test_class_command.py'],
     re.compile('tern/classes/docker_image.py'):
-    'python tests/test_class_docker_image.py',
-    re.compile('tern/classes/image.py'): 'python tests/test_class_image.py',
+    ['python tests/test_class_docker_image.py'],
+    re.compile('tern/classes/image.py'):
+    ['python tests/test_class_image.py'],
     re.compile('tern/classes/image_layer.py'):
-    'python tests/test_class_image_layer.py',
-    re.compile('tern/classes/notice.py'): 'python tests/test_class_notice.py',
+    ['python tests/test_class_image_layer.py'],
+    re.compile('tern/classes/notice.py'):
+    ['python tests/test_class_notice.py'],
     re.compile('tern/classes/notice_origin.py'):
-    'python tests/test_class_notice_origin.py',
+    ['python tests/test_class_notice_origin.py'],
     re.compile('tern/classes/origins.py'):
-    'python tests/test_class_origins.py',
+    ['python tests/test_class_origins.py'],
     re.compile('tern/classes/package.py'):
-    'python tests/test_class_package.py',
+    ['python tests/test_class_package.py'],
     re.compile('tern/classes/template.py'):
-    'python tests/test_class_template.py',
+    ['python tests/test_class_template.py'],
     # tern/command_lib
     re.compile('tern/command_lib'): [
         'tern -l report -i photon:3.0',
@@ -78,41 +80,38 @@ test_suite = {
         'tern -l report -m spdxtagvalue -i photon:3.0',
         'tern -l report -d samples/alpine_python/Dockerfile'],
     # tern/tools
-    re.compile('tern/tools'): 'tern -l report -i golang:alpine',
+    re.compile('tern/tools'):
+    ['tern -l report -i golang:alpine'],
     # tern/utils
     re.compile('tern/utils'): [
         'tern -l report -i golang:alpine',
         'tern -l report -d samples/alpine_python/Dockerfile'],
     # tests
     re.compile('tests/test_class_command.py'):
-        'python tests/test_class_command.py',
+        ['python tests/test_class_command.py'],
     re.compile('tests/test_class_docker_image.py'):
-        'python tests/test_class_docker_image.py',
+        ['python tests/test_class_docker_image.py'],
     re.compile('tests/test_class_image.py'):
-        'python tests/test_class_image.py',
+        ['python tests/test_class_image.py'],
     re.compile('tests/test_class_image_layer.py'):
-        'python tests/test_class_image_layer.py',
+        ['python tests/test_class_image_layer.py'],
     re.compile('tests/test_class_notice.py'):
-        'python tests/test_class_notice.py',
+        ['python tests/test_class_notice.py'],
     re.compile('tests/test_class_notice_origin.py'):
-        'python tests/test_class_notice_origin.py',
+        ['python tests/test_class_notice_origin.py'],
     re.compile('tests/test_class_origins.py'):
-        'python tests/test_class_origins.py',
+        ['python tests/test_class_origins.py'],
     re.compile('tests/test_class_package.py'):
-        'python tests/test_class_package.py',
+        ['python tests/test_class_package.py'],
     re.compile('tests/test_class_template.py'):
-        'python tests/test_class_template.py'
+        ['python tests/test_class_template.py']
         }
 
 alltests = []
 for change in changes:
     for check in test_suite.keys():
         if check.match(change):
-            # add to list differently based on type
-            if isinstance(test_suite[check], list):
-                alltests.extend(test_suite[check])
-            else:
-                alltests.append(test_suite[check])
+            alltests.extend(test_suite[check])
 
 # Remove duplicate tests
 tests = list(set(alltests))


### PR DESCRIPTION
The test_suite dictionary in 'ci/test_files_touched' used to contain
values of mixed types (both strings and lists of strings). As a result,
we were checking for the instance type before adding the value to the
alltests string.

This commit makes the following change:
  1) Changes all values in tests_suite to lists of strings, even if the
     list is only one element.
  2) Removes the isinstance check before extending the value to alltests

Resolves #322

Signed-off-by: Rose Judge <rjudge@vmware.com>