### PR TITLE
DO NOT MERGE: ci: Enable linting for each .py file in the PR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,10 +26,6 @@ jobs:
       - run: pip install -r dev-requirements.txt
       - run: pip install .
       - run: python ci/evaluate_docs.py
-      - run:
-         name: Prospector
-         when: on_success
-         command: prospector .
   # security linting using Bandit
   security:
     executor: ubuntu1604


### PR DESCRIPTION
This is a quick fix that resolves #323 in the short term.

Prospector only runs PEP8 checks for files within modules but not
for excluded files. It works for individual files. The fix involves
repurposing the evaluate_docs.py check to instead run prospector on
files that are .py files. This automatically covers not running
linting for .md or .yml files.

- Modify evaluate_docs.py to lint changed files if they have a .py
extention.
- Modify the CircleCI config file to remove the conditional test and
just run the evaluate_docs.py script

Signed-off-by: Nisha K <nishak@vmware.com>