### PR TITLE
ci: Enable linting for each .py file in the PR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,11 +25,7 @@ jobs:
       - setup
       - run: pip install -r dev-requirements.txt
       - run: pip install .
-      - run: python ci/evaluate_docs.py
-      - run:
-         name: Prospector
-         when: on_success
-         command: prospector .
+      - run: python ci/evaluate_docs.py | xargs prospector
   # security linting using Bandit
   security:
     executor: ubuntu1604
@@ -37,7 +33,7 @@ jobs:
     steps:
       - setup
       - run: pip install -r dev-requirements.txt
-      - run: bandit -r .
+      - run: python ci/evaluate_docs.py | xargs bandit
   # linting for PR commit messages
   commit_check:
     executor: ubuntu1604

--- a/ci/evaluate_docs.py
+++ b/ci/evaluate_docs.py
@@ -5,18 +5,10 @@
 
 from git import Repo
 import os
-import sys
 
-
-# This script is designed to be run with circleci.
-# This script should pass if we need to run Bandit and Prospector,
-# which means that there are files other than *.md files being changed.
-# If only *.md files are changed, we don't need to run Bandit
-# or Prospector and the script will fail.
-
-# Assume that all files are *.md until proven otherwise
-docs_only = True
-
+# This is meant to run within circleci
+# Print out only .py files that have changed
+# Pipe to any linting tools
 
 repo = Repo(os.getcwd())
 repo.git.remote('add', 'upstream', 'git@github.com:vmware/tern.git')
@@ -25,22 +17,9 @@ repo.git.fetch('upstream')
 hcommit = repo.head.commit
 diff = hcommit.diff('upstream/master')
 
-changes=[]
+if not diff:
+    print('No changes to lint.')
+
 for d in diff:
-    # Get the list of strings for changed files
-    changes.append(d.b_path)
-
-# check that changes has entries
-if not changes:
-    print('No changes to run tests for.')
-    sys.exit(0)
-
-for change in changes:
-    if change[-3:] != '.md':
-        docs_only = False
-        break
-
-if docs_only:
-    sys.exit(1)
-else:
-    sys.exit(0)
+    if os.path.exists(d.b_path) and (d.b_path)[-3:] == '.py':
+        print(d.b_path)


### PR DESCRIPTION
This is a quick fix that resolves #323 in the short term.

Prospector only runs PEP8 checks for files within modules but not
for excluded files. It works for individual files. The fix involves
repurposing the evaluate_docs.py to print to stdout the files that
changed. This result can then be piped to any linting tool.

- Modify evaluate_docs.py to print files that have the .py extention
and exist in the filesystem
- Modify the CircleCI config file to remove the conditional test, run
the evaluate_docs.py script and then pipe it to prospector and bandit

Signed-off-by: Nisha K <nishak@vmware.com>