### PR TITLE
ci: Fix pipe error if there are no changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
       - setup
       - run: pip install -r dev-requirements.txt
       - run: pip install .
-      - run: python ci/evaluate_docs.py | xargs prospector
+      - run: c=`python ci/evaluate_docs.py`; if [ -z $c ]; then echo "No .py files to lint"; else echo $c | xargs prospector; fi
   # security linting using Bandit
   security:
     executor: ubuntu1604
@@ -33,7 +33,7 @@ jobs:
     steps:
       - setup
       - run: pip install -r dev-requirements.txt
-      - run: python ci/evaluate_docs.py | xargs bandit
+      - run: c=`python ci/evaluate_docs.py`; if [ -z $c ]; then echo "No .py files to lint"; else echo $c | xargs bandit; fi
   # linting for PR commit messages
   commit_check:
     executor: ubuntu1604

--- a/ci/evaluate_docs.py
+++ b/ci/evaluate_docs.py
@@ -5,10 +5,13 @@
 
 from git import Repo
 import os
+import sys
 
 # This is meant to run within circleci
 # Print out only .py files that have changed
 # Pipe to any linting tools
+# Note that some linting tools will lint everything if the output
+# of this script is nothing
 
 repo = Repo(os.getcwd())
 repo.git.remote('add', 'upstream', 'git@github.com:vmware/tern.git')
@@ -18,7 +21,7 @@ hcommit = repo.head.commit
 diff = hcommit.diff('upstream/master')
 
 if not diff:
-    print('No changes to lint.')
+    sys.exit(0)
 
 for d in diff:
     if os.path.exists(d.b_path) and (d.b_path)[-3:] == '.py':


### PR DESCRIPTION
In the case where there are no changes, evaluate_docs.py will
print a helpful message, which doesn't play well if piped to
linting tools. Instead modifying the script to only print out files
when they are changed and nothing if there are no changes.

Then modifying the run command in CircleCI with assigning the output
to an environment variable, and then checking to see if it is empty
or not.

Signed-off-by: Nisha K <nishak@vmware.com>