### PR TITLE
Debug a container image (somewhat)

### DIFF
--- a/tern/report/report.py
+++ b/tern/report/report.py
@@ -171,8 +171,7 @@ def mount_overlay_fs(image_obj, top_layer):
     for index in range(0, top_layer + 1):
         tar_layers.append(image_obj.layers[index].tar_file)
     target = rootfs.mount_diff_layers(tar_layers)
-    # mount dev, sys and proc after mounting diff layers
-    rootfs.prep_rootfs(target)
+    return target
 
 
 def analyze_docker_image(image_obj, redo=False, dockerfile=False):  # pylint: disable=too-many-locals
@@ -245,7 +244,9 @@ def analyze_docker_image(image_obj, redo=False, dockerfile=False):  # pylint: di
                 image_obj.layers[curr_layer])
             if command_list:
                 # mount diff layers from 0 till the current layer
-                mount_overlay_fs(image_obj, curr_layer)
+                target = mount_overlay_fs(image_obj, curr_layer)
+                # mount dev, sys and proc after mounting diff layers
+                rootfs.prep_rootfs(target)
             # for each command look up the snippet library
             for command in command_list:
                 pkg_listing = command_lib.get_package_listing(command.name)

--- a/tern/tools/container_debug.py
+++ b/tern/tools/container_debug.py
@@ -1,0 +1,128 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""
+A tool to debug a container image
+Specify at what layer you want to debug the container
+If the container has only one layer, that is the only option available
+"""
+
+import argparse
+import os
+import subprocess  # nosec
+import sys
+
+from tern.utils import rootfs
+from tern.utils import constants
+from tern.report import report
+
+
+def cleanup():
+    """Clean up the working directory"""
+    rootfs.clean_up()
+    report.clean_working_dir(False)
+
+
+def unmount():
+    """Go through unmounting the working directory"""
+    # try to unmount proc, sys and dev
+    try:
+        rootfs.undo_mount()
+    except subprocess.CalledProcessError:
+        pass
+    try:
+        rootfs.unmount_rootfs()
+    except subprocess.CalledProcessError:
+        pass
+
+
+def get_mount_path():
+    """Get the path where the filesystem is mounted"""
+    return os.path.join(os.getcwd(), constants.temp_folder, constants.mergedir)
+
+
+def check_shell():
+    """Check if any shell binary is available in the mounted filesystem"""
+    shells = ['/bin/sh', '/bin/bash', '/usr/bin/bash']
+    cwd = get_mount_path()
+    for shell in shells:
+        if os.path.exists(os.path.join(cwd, shell[1:])):
+            return shell
+    return ''
+
+
+def drop_into_layer(image_obj, layer_index):
+    """Given the image object and the layer index, mount all the layers
+    upto the specified layer index and drop into a shell session"""
+    rootfs.set_up()
+    if layer_index == 0:
+        # mount only one layer
+        target = rootfs.mount_base_layer(
+            image_obj.layers[layer_index].tar_file)
+    else:
+        # mount all layers uptil the provided layer index
+        target = report.mount_overlay_fs(image_obj, layer_index)
+    # check if there is a shell
+    shell = check_shell()
+    if shell:
+        rootfs.prep_rootfs(target)
+        print("Done. Run 'sudo chroot . {}' to look around.".format(shell))
+    else:
+        print("A shell binary doesn't exist in the filesystem. You're on "
+              "your own.")
+    print("Working directory is: {}".format(get_mount_path()))
+    sys.exit(0)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description='''
+        A tool to debug a given container image.
+        Give the name of the container image on disk (Eg: golang:alpine)
+        and the tool will untar the container image and list out all
+        the layers in the image. Then you can pick which layer you
+        want to be dropped into''')
+    parser.add_argument('--image', metavar='IMAGE',
+                        help='Name of image. Eg: docker.io/golang:latest')
+    parser.add_argument('--clean', action='store_true',
+                        help='Clean up the mounts')
+    args = parser.parse_args()
+
+    # check if we need to clean
+    if args.clean:
+        unmount()
+        cleanup()
+        sys.exit(0)
+
+    # first, list all the layers in the image in this format
+    # [<layer number>] created_by
+    report.setup(image_tag_string=args.image)
+    image_obj = report.load_full_image(args.image)
+    if image_obj.origins.is_empty():
+        # image loading was successful
+        # list all the layers
+        for layer in image_obj.layers:
+            created_by = layer.created_by if layer.created_by else 'unknown'
+            print("[{}] {}".format(image_obj.layers.index(layer), created_by))
+        try:
+            while True:
+                try:
+                    # input is safe in Python3
+                    top_layer = int(input("Pick a layer to debug: "))  # nosec
+                except ValueError:
+                    print("Not an integer")
+                    continue
+                if not 0 <= top_layer < len(image_obj.layers):
+                    print("Not a valid layer number")
+                    continue
+                else:
+                    break
+            drop_into_layer(image_obj, top_layer)
+        except KeyboardInterrupt:
+            print("Exiting...")
+            cleanup()
+    else:
+        print("Something when wrong in loading the image")
+        cleanup()

--- a/tern/tools/verify_invoke.py
+++ b/tern/tools/verify_invoke.py
@@ -54,9 +54,9 @@ if __name__ == '__main__':
         if len(image_obj.layers) == 1:
             # mount only one layer
             target = rootfs.mount_base_layer(image_obj.layers[0].tar_file)
-            rootfs.prep_rootfs(target)
         else:
             report.mount_overlay_fs(image_obj, len(image_obj.layers) - 1)
+        rootfs.prep_rootfs(target)
         # invoke commands in chroot
         # if we're looking up the snippets library
         # we should see 'snippets' in the keys

--- a/tern/utils/rootfs.py
+++ b/tern/utils/rootfs.py
@@ -174,8 +174,8 @@ def calc_fs_hash(fs_path):
     directory.
     Note that this file will be deleted if the -k flag is not given'''
     try:
-        fs_hash_path = pkg_resources.resource_filename("tern",
-                "tools/fs_hash.sh")
+        fs_hash_path = pkg_resources.resource_filename(
+            "tern", "tools/fs_hash.sh")
         hash_contents = root_command(
             [fs_hash_path], os.path.abspath(fs_path))
         file_name = hashlib.sha256(hash_contents).hexdigest()


### PR DESCRIPTION
This PR consists of the following commits:
1. Does some modification on separating mounting the overlay filesystem and mounting proc, sys and dev
2. A PEP8 fix
3. The python script that can be used to debug a container image

The script is a little clunky to use right now, but it is good enough for basic container image debugging, i.e. cd to the mount point and poke around.