### PR TITLE
Fix incorrect test to run in circleci

### DIFF
--- a/ci/test_files_touched.py
+++ b/ci/test_files_touched.py
@@ -74,7 +74,7 @@ test_suite = {
     # tern/report
     re.compile('tern/report'): [
         'tern -l report -i golang:alpine',
-        'tern -l report -j photon:3.0',
+        'tern -l report -j -i photon:3.0',
         'tern -l report -y -i photon:3.0',
         'tern -l report -s -i photon:3.0',
         'tern -l report -m spdxtagvalue -i photon:3.0',


### PR DESCRIPTION
If any file under tern/report changes, we need to run a set of tests.
One of those tests was recorded incorrectly in the test_suite
dictionary. This commit address that and makes the fix so the test will
run correctly in circleci.

Signed-off-by: Rose Judge <rjudge@vmware.com>