### PR TITLE
ci/cd:Add long_description_content_type to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
     description=("An inspection tool to find the OSS compliance metadata of"
                  " the packages installed in a container image."),
     long_descrition=_read_long_desc(),
+    long_description_content_type='text/markdown',
     license="BSD-2.0",
     keywords="Distribution, Container, Cloud-Native",
     classifiers=[


### PR DESCRIPTION
Add long_description_content_type to setup.py to avoid converting README.md to README.rst

Resolves: #331 
