### PR TITLE
Add pkg_format to each package manager in base.yml

### DIFF
--- a/tern/command_lib/base.yml
+++ b/tern/command_lib/base.yml
@@ -4,6 +4,7 @@
 # Known package listings for base images
 # Format to list images
 # <package manager>:
+#   pkg_format: <the package format used by the package manager>
 #   shell: <the shell executable> (needed if entering code snippets)
 #   names: <a list of package names>
 #     invoke: (if this is a script to invoke include this)
@@ -15,6 +16,7 @@
 
 # tdnf ---------------------------------------------------------------------------------------------------------------------------------
 tdnf:
+  pkg_format: 'rpm'
   path:
     - 'usr/bin/tdnf' # don't put forward slash here as os.path.join will think it is the root directory on the host
   shell: '/usr/bin/bash'
@@ -54,6 +56,7 @@ tdnf:
 
 # dpkg -------------------------------------------------------------------------------------------------------------------------------
 dpkg:
+  pkg_format: 'deb'
   path:
     - 'usr/bin/dpkg'
   shell: '/bin/bash'
@@ -84,6 +87,7 @@ dpkg:
 
 # apk ---------------------------------------------------------------------------------------------------------
 apk:
+  pkg_format: 'apk'
   path:
     - 'sbin/apk'
   shell: '/bin/sh'
@@ -119,6 +123,7 @@ apk:
 
 # pacman ----------------------------------------------------------------------
 pacman:
+  pkg_format: 'pkg.tar.xz'
   path:
     - 'usr/bin/pacman'
   shell: '/usr/bin/sh'
@@ -149,6 +154,7 @@ pacman:
 
 # rpm ----------------------------------------------------------------------
 rpm:
+  pkg_format: 'rpm'
   path:
     - 'usr/bin/rpm'
   shell: '/usr/bin/sh'


### PR DESCRIPTION
This commit introduces a package format value (pkg_format) associated
with each of the package managers in base.yml. It also updates the
documentation in base.yml for reference.

Resolves #332

Signed-off-by: Rose Judge <rjudge@vmware.com>