### PR TITLE
Add pkg_format attribute to image_layer class

### DIFF
--- a/tern/classes/image_layer.py
+++ b/tern/classes/image_layer.py
@@ -44,6 +44,7 @@ class ImageLayer:
         self.__origins = Origins()
         self.__import_image = None
         self.__import_str = ''
+        self.__pkg_format = ''
 
     @property
     def diff_id(self):
@@ -88,6 +89,14 @@ class ImageLayer:
     @import_str.setter
     def import_str(self, import_str):
         self.__import_str = import_str
+
+    @property
+    def pkg_format(self):
+        return self.__pkg_format
+
+    @pkg_format.setter
+    def pkg_format(self, pkg_format):
+        self.__pkg_format = pkg_format
 
     def add_package(self, package):
         if isinstance(package, Package):

--- a/tests/test_class_image_layer.py
+++ b/tests/test_class_image_layer.py
@@ -30,6 +30,8 @@ class TestClassImageLayer(unittest.TestCase):
                           'some/other/path')
         self.layer.created_by = 'some string'
         self.assertEqual(self.layer.created_by, 'some string')
+        self.layer.pkg_format = 'rpm'
+        self.assertEqual(self.layer.pkg_format, 'rpm')
 
     def testAddPackage(self):
         err = "Object type String, should be Package"


### PR DESCRIPTION
This commit does four things:
  1) Adds pkg_format as an attribute for an ImageLayer object.
  2) Uses @property to create a getter method for the pkg_format of an
     ImageLayer object.
  3) Creates a setter method to assign the pkg_format to an ImageLayer
     object.
  4) Adds a check in tests/test_class_image_layer.py to verify the
     get/set functionality added in the 3 points above.

Resolves #335

Signed-off-by: Rose Judge <rjudge@vmware.com>