### PR TITLE
command_lib: Add check_pkg_format function

### DIFF
--- a/tern/command_lib/command_lib.py
+++ b/tern/command_lib/command_lib.py
@@ -31,7 +31,8 @@ with open(os.path.abspath(base_file)) as f:
 with open(os.path.abspath(snippet_file)) as f:
     command_lib['snippets'] = yaml.safe_load(f)
 # list of package information keys that the command library can accomodate
-base_keys = {'names', 'versions', 'licenses', 'copyrights', 'proj_urls', 'srcs'}
+base_keys = {'names', 'versions', 'licenses', 'copyrights', 'proj_urls',
+             'srcs'}
 package_keys = {'name', 'version', 'license', 'copyright', 'proj_url', 'src'}
 
 # global logger
@@ -266,3 +267,10 @@ def check_sourcable(command, package_name):
                         'src' in package.keys():
                     sourcable = True
     return sourcable
+
+
+def check_pkg_format(pkgmanager):
+    try:
+        return command_lib['base'][pkgmanager]['pkg_format']
+    except KeyError:
+        return ''


### PR DESCRIPTION
This commit does two things:
  1) Adds a function called check_pkg_format which takes a package
     manager as input and outputs the associated package format
     according to the base.yml file. If the given package manager
     does not exist, the function will return an empty string.
  2) Fixes a line where the character count was longer than allowed by
     PEP8 standards.

Resolves #337

Signed-off-by: Rose Judge <rjudge@vmware.com>