### PR TITLE
command_lib: Change variable name for consistency

### DIFF
--- a/tern/command_lib/command_lib.py
+++ b/tern/command_lib/command_lib.py
@@ -269,8 +269,8 @@ def check_sourcable(command, package_name):
     return sourcable
 
 
-def check_pkg_format(pkgmanager):
+def check_pkg_format(binary):
     try:
-        return command_lib['base'][pkgmanager]['pkg_format']
+        return command_lib['base'][binary]['pkg_format']
     except KeyError:
         return ''


### PR DESCRIPTION
In commit 89d8259, the check_pkg_format function was introduced into
tern/command_lib/command_lib.py and the input variable was called
'pkgmanager'. However, in other files throughout the code, the package
manager is referred to as the 'binary' which is used to identify the
base OS layer.

This commit changes the input variable name in the check_pkg_format
function to 'binary' to be consistent with other references throughout
the project.

See also #337

Signed-off-by: Rose Judge <rjudge@vmware.com>