### PR TITLE
Add functionality to report repo style and distro of a container

### DIFF
--- a/tern/classes/image_layer.py
+++ b/tern/classes/image_layer.py
@@ -45,6 +45,7 @@ class ImageLayer:
         self.__import_image = None
         self.__import_str = ''
         self.__pkg_format = ''
+        self.__os_guess = ''
 
     @property
     def diff_id(self):
@@ -97,6 +98,14 @@ class ImageLayer:
     @pkg_format.setter
     def pkg_format(self, pkg_format):
         self.__pkg_format = pkg_format
+
+    @property
+    def os_guess(self):
+        return self.__os_guess
+
+    @os_guess.setter
+    def os_guess(self, os_guess):
+        self.__os_guess = os_guess
 
     def add_package(self, package):
         if isinstance(package, Package):

--- a/tern/command_lib/base.yml
+++ b/tern/command_lib/base.yml
@@ -17,6 +17,8 @@
 # tdnf ---------------------------------------------------------------------------------------------------------------------------------
 tdnf:
   pkg_format: 'rpm'
+  os_guess:
+    - 'Photon'
   path:
     - 'usr/bin/tdnf' # don't put forward slash here as os.path.join will think it is the root directory on the host
   shell: '/usr/bin/bash'
@@ -57,6 +59,9 @@ tdnf:
 # dpkg -------------------------------------------------------------------------------------------------------------------------------
 dpkg:
   pkg_format: 'deb'
+  os_guess:
+    - 'Debian'
+    - 'Ubuntu'
   path:
     - 'usr/bin/dpkg'
   shell: '/bin/bash'
@@ -88,6 +93,8 @@ dpkg:
 # apk ---------------------------------------------------------------------------------------------------------
 apk:
   pkg_format: 'apk'
+  os_guess:
+    - 'Alpine Linux'
   path:
     - 'sbin/apk'
   shell: '/bin/sh'
@@ -124,6 +131,8 @@ apk:
 # pacman ----------------------------------------------------------------------
 pacman:
   pkg_format: 'pkg.tar.xz'
+  os_guess:
+    - 'Arch Linux'
   path:
     - 'usr/bin/pacman'
   shell: '/usr/bin/sh'
@@ -155,6 +164,11 @@ pacman:
 # rpm ----------------------------------------------------------------------
 rpm:
   pkg_format: 'rpm'
+  os_guess:
+    - 'CentOS'
+    - 'Fedora'
+    - 'openSUSE'
+    - 'RHEL'
   path:
     - 'usr/bin/rpm'
   shell: '/usr/bin/sh'

--- a/tern/command_lib/command_lib.py
+++ b/tern/command_lib/command_lib.py
@@ -270,7 +270,23 @@ def check_sourcable(command, package_name):
 
 
 def check_pkg_format(binary):
+    '''Given a binary package manager, return the associated pkg_format from
+    base.yml. If the binary is not valid in base.yml, return an empty
+    string.'''
     try:
         return command_lib['base'][binary]['pkg_format']
+    except KeyError:
+        return ''
+
+
+def check_os_guess(binary):
+    '''Given a binary package manager, return the associated os_guess from
+    base.yml. If the binary is not valid in base.yml, return an empty
+    string.'''
+    os_list = []
+    try:
+        for o in command_lib['base'][binary]['os_guess']:
+            os_list.append(o)
+        return ', '.join(os_list)
     except KeyError:
         return ''

--- a/tern/helpers/common.py
+++ b/tern/helpers/common.py
@@ -380,3 +380,18 @@ def update_master_list(master_list, layer_obj):
     while unique:
         layer_obj.packages.append(unique.pop(0))
     del unique
+
+
+def get_os_style(image_layer, binary):
+    '''Given an ImageLayer object and a binary package manager, determine if
+    the package manager has a pkg_format associated with it. If the binary
+    does not exist in base.yml, add a notice to the layer's origins'''
+    origin_command_lib = formats.invoking_base_commands
+    pkg_format = command_lib.check_pkg_format(binary)
+    if not pkg_format:
+        # empty string means binary is not found in base.yml
+        image_layer.origins.add_notice_to_origins(
+            origin_command_lib, Notice(errors.no_listing_for_base_key.format(
+                listing_key=binary), 'warning'))
+    else:
+        image_layer.pkg_format = pkg_format

--- a/tern/helpers/common.py
+++ b/tern/helpers/common.py
@@ -82,6 +82,34 @@ def get_base_bin():
     return binary
 
 
+def get_os_release():
+    '''Given the base layer object, determine if an os-release file exists and
+    return the PRETTY_NAME string from it. If no release file exists,
+    return an empty string. Assume that the layer filesystem is mounted'''
+    # os-release may exist under /etc/ or /usr/lib. We should first check
+    # for the preferred /etc/os-release and fall back on /usr/lib/os-release
+    # if it does not exist under /etc
+    etc_path = os.path.join(os.getcwd(), constants.temp_folder,
+                            constants.mergedir, constants.etc_release_path)
+    lib_path = os.path.join(os.getcwd(), constants.temp_folder,
+                            constants.mergedir, constants.lib_release_path)
+    if not os.path.exists(etc_path):
+        if not os.path.exists(lib_path):
+            return ''
+        etc_path = lib_path
+    # file exists at this point, try to read it
+    with open(etc_path, 'r') as f:
+        lines = f.readlines()
+    pretty_name = ''
+    # iterate through os-release file to find OS
+    for l in lines:
+        key, val = l.rstrip().split('=', 1)
+        if key == "PRETTY_NAME":
+            pretty_name = val
+            break
+    return pretty_name.strip('"')
+
+
 def collate_list_metadata(shell, listing):
     '''Given the shell and the listing for the package manager, collect
     metadata that gets returned as a list'''
@@ -383,15 +411,33 @@ def update_master_list(master_list, layer_obj):
 
 
 def get_os_style(image_layer, binary):
-    '''Given an ImageLayer object and a binary package manager, determine if
-    the package manager has a pkg_format associated with it. If the binary
-    does not exist in base.yml, add a notice to the layer's origins'''
+    '''Given an ImageLayer object and a binary package manager, check for the
+    OS identifier in the os-release file first. If the os-release file
+    is not available, make an educated guess as to what kind of OS the layer
+    might be based off of given the pkg_format + package manager. If the binary
+    provided does not exist in base.yml, add a warning notice'''
     origin_command_lib = formats.invoking_base_commands
+    origin_layer = 'Layer: ' + image_layer.fs_hash[:10]
     pkg_format = command_lib.check_pkg_format(binary)
-    if not pkg_format:
-        # empty string means binary is not found in base.yml
-        image_layer.origins.add_notice_to_origins(
-            origin_command_lib, Notice(errors.no_listing_for_base_key.format(
-                listing_key=binary), 'warning'))
+    os_guess = command_lib.check_os_guess(binary)
+    if get_os_release():
+        # We know with high degree of certainty what the OS is
+        image_layer.origins.add_notice_to_origins(origin_layer, Notice(
+            formats.os_release.format(os_style=get_os_release()), 'info'))
     else:
-        image_layer.pkg_format = pkg_format
+        # We make a guess about the OS based on pkg_format + binary
+        # First check that binary exists in base.yml
+        if not pkg_format or not os_guess:
+            image_layer.origins.add_notice_to_origins(
+                origin_command_lib, Notice(
+                    errors.no_listing_for_base_key.format(listing_key=binary),
+                    'warning'))
+        else:
+            # Assign image layer attributes
+            image_layer.pkg_format = pkg_format
+            image_layer.os_guess = os_guess
+            image_layer.origins.add_notice_to_origins(origin_layer, Notice(
+                formats.os_style_guess.format(
+                    package_manager=binary,
+                    package_format=image_layer.pkg_format,
+                    os_list=image_layer.os_guess), 'info'))

--- a/tern/report/formats.py
+++ b/tern/report/formats.py
@@ -57,6 +57,10 @@ invoking_snippet_commands = '''Invoking commands from ''' \
     '''command_lib/snippets.yml'''
 ignored = '''\nIgnored Commands:'''
 unrecognized = '''\nUnrecognized Commands:'''
+os_style_guess = '''Found {package_manager} package manager with '''\
+    '''{package_format} package format. Possible OS(es) for this layer '''\
+    '''might be: {os_list}'''
+os_release = '''Found '{os_style}' in /etc/os-release.'''
 
 # report formatting for dockerfiles
 

--- a/tern/report/report.py
+++ b/tern/report/report.py
@@ -174,7 +174,8 @@ def mount_overlay_fs(image_obj, top_layer):
     return target
 
 
-def analyze_docker_image(image_obj, redo=False, dockerfile=False):  # pylint: disable=too-many-locals
+def analyze_docker_image(image_obj, redo=False,
+                         dockerfile=False):  # pylint: disable=too-many-locals
     '''Given a DockerImage object, for each layer, retrieve the packages, first
     looking up in cache and if not there then looking up in the command
     library. For looking up in command library first mount the filesystem
@@ -215,6 +216,8 @@ def analyze_docker_image(image_obj, redo=False, dockerfile=False):  # pylint: di
     # cached
     if binary:
         if not common.load_from_cache(image_obj.layers[0], redo):
+            # Determine pacakge/os style from binary in the image layer
+            common.get_os_style(image_obj.layers[0], binary)
             # get the packages of the first layer
             rootfs.prep_rootfs(target)
             common.add_base_packages(image_obj.layers[0], binary, shell)

--- a/tern/report/report.py
+++ b/tern/report/report.py
@@ -174,8 +174,7 @@ def mount_overlay_fs(image_obj, top_layer):
     return target
 
 
-def analyze_docker_image(image_obj, redo=False,
-                         dockerfile=False):  # pylint: disable=too-many-locals
+def analyze_docker_image(image_obj, redo=False, dockerfile=False): # pylint: disable=too-many-locals
     '''Given a DockerImage object, for each layer, retrieve the packages, first
     looking up in cache and if not there then looking up in the command
     library. For looking up in command library first mount the filesystem

--- a/tern/utils/constants.py
+++ b/tern/utils/constants.py
@@ -30,6 +30,9 @@ cache_file = 'cache.yml'
 shell = '/bin/sh'
 # path where resolv.conf lives
 resolv_path = '/etc/resolv.conf'
+# paths where os-release could be
+etc_release_path = 'etc/os-release'
+lib_release_path = 'usr/lib/os-release'
 # directory where layer.tar can be extracted to
 untar_dir = 'contents'
 # rootfs working directory

--- a/tests/test_class_image_layer.py
+++ b/tests/test_class_image_layer.py
@@ -32,6 +32,8 @@ class TestClassImageLayer(unittest.TestCase):
         self.assertEqual(self.layer.created_by, 'some string')
         self.layer.pkg_format = 'rpm'
         self.assertEqual(self.layer.pkg_format, 'rpm')
+        self.layer.os_guess = 'operating system'
+        self.assertEqual(self.layer.os_guess, 'operating system')
 
     def testAddPackage(self):
         err = "Object type String, should be Package"


### PR DESCRIPTION
UPDATED: to include feedback from Joshua to utilize /etc/os-release

This is a fairly large PR that adds functionality for Tern to report
what repo style and distro the container image is based off of. The
following changes were made to the files listed below:

1) tern/command_lib/base.yml
   Add an `os_guess` section for each package manager entry. `os_guess`
   is a list of possible OSes for the given pkg manager.

2) tern/classes/image_layer.py
   Add an `os_guess` attribute to the ImageLayer class. This also
   includes adding a @Property python decorator for it and a setter
   method to access the `os_guess` value.

3) tests/test_class_image_layer.py
   Add a check to verify the functionality of the getter and setter
   methods for `os_guess` in the ImageLayer class.

4) tern/command_lib/command_lib.py
   Adds a `check_os_guess` function that will return the list of os_guess
   values associated with a given binary (provided that the binary
   exists in base.yml). If the binary provided does not exist in
   base.yml, return a blank string.

5) tern/helpers/common.py
  - Adds a function called `get_os_release` that checks the
   `/etc/os-release` file of the mounted image layer for OS information.
   If no information can be found it returns a blank string.
- Creates a new function called `get_os_style` which outputs the
   distro based on `/etc/os-release` (if the file exists), otherwise makes
   makes an educated guess as to the OS style based on the binary and
   pkg_format in base.yml. 

6) tern/report/formats.py
   Add two os_style-related reports to format the OS suggestion in the
   final report based on where the OS information was gathered from.

7) tern/report/report.py
    Adds a call to `get_os_style` inside the `analyze_docker_image` function.

8) tern/utils/constants
   Add the two paths where the os-release file could be.

Resolves #161
Resolves #338

--------------------------------------------------------------------------------------
I tested this PR code by running `tern -l report -i golang:alpine -f output.txt` and saw the following at the top of output.txt:
```
Docker image: golang:alpine:
        Layer: 65eaf5c9b8:
                info: Found 'Alpine Linux v3.10' in /etc/os-release.
                info: Layer created by commands: /bin/sh -c #(nop) ADD file:fef3b00b3ae63967d8f4d83174b3fcecb55c9bada02b3e4f5a9b79a21b6c3bb3 in /

```
