### PR TITLE
ci/cd: Create build and release pipeline for Tern

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,14 @@ commands:
       - checkout
       - run: pyenv global 3.6.5
       - run: pip install --upgrade pip
+  create_pypirc:
+    steps:
+      - run:
+          name: Create pypirc file
+          command: |
+           echo -e "[pypi]" >> ~/.pypirc
+           echo -e "username = $R_PYPI_UN" >> ~/.pypirc
+           echo -e "password = $PYPI_PW" >> ~/.pypiruc
 
 jobs:
   # linting using Prospector
@@ -58,8 +66,20 @@ jobs:
       - setup
       - run: pip install .
       - run: tern -l report -i photon:3.0
+  # Deploy to PyPi
+  pypi_deploy:
+   executor: ubuntu1604
+   steps:
+      - setup
+      - run: pip install .
+      - run: pip install twine
+      # make sure git tag matches release version
+      - run: python setup.py verify
+      - create_pypirc 
+      - run: python setup.py sdist
+      - run: twine upload dist/* 
+
 workflows:
-  # run a full functional test for photonOS
   version: 2
   PRs:
     jobs:
@@ -67,3 +87,13 @@ workflows:
       - commit_check
       - security
       - test_changes
+  Release:
+    jobs:
+      - pypi_deploy:
+          filters:
+            # ignore all commits on any branch by default
+            branches:
+              ignore: /.*/
+            # only run on version tags
+            tags:
+              only: /^v[0-9]+(\.[0-9]+)*$/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,5 @@
 include tern/command_lib/*.yml
 include tern/tools/fs_hash.sh
 recursive-include tern/scripts *.sh *.list
+prune ci
+prune tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,46 @@
+#!/usr/bin/env python                                                           
+# -*- coding: utf-8 -*-                                                         
+#                                                                               
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.                          
+# SPDX-License-Identifier: BSD-2-Clause
+
+[metadata]
+name = tern
+author = VMware Inc
+author-email = nishak@vmware.com
+summary = An inspection tool to find the OSS compliance metadata of the packages installed in a container image.
+description-file = README.md
+description-content-type = text/markdown; charset=UTF-8
+home-page = https://github.com/vmware/tern/
+project_urls =
+    Documentation = https://github.com/vmware/tern/tree/master/docs
+    Source Code = https://github.com/vmware/tern 
+    Issues = https://github.com/vmware/tern/issues
+license = BSD-2.0
+keywords = 
+    Distribution
+    Container
+    Cloud-Native
+classifier = 
+    Development Status :: 3 - Alpha
+    Environment :: Console
+    Intended Audience :: Developers
+    License :: OSI Approved :: BSD License
+    Natural Language :: English
+    Operating System :: POSIX
+    Operating System :: POSIX :: Linux
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: Implementation :: CPython
+    Topic :: Software Development
+
+[files]
+packages = 
+    tern
+
+[options]
+include_package_data = True
+
+[entry_points]
+console_scripts = 
+    tern = tern.__main__:main

--- a/setup.py
+++ b/setup.py
@@ -4,52 +4,31 @@
 # Copyright (c) 2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
-from setuptools import setup, find_packages
+import os
+import sys
 
 from tern import Version
+from setuptools.command.install import install
+from setuptools import setup
 
 
-def _read_long_desc():
-    with open("README.md") as fp:
-        return fp.read()
+class VerifyVersion(install):
+    """Run a custom verify command"""
+    description = "Verify that the git tag matches current release version."
 
-
-def _get_requirements():
-
-    with open("requirements.txt") as fp:
-        return [requirement for requirement in fp]
+    def run(self):
+        tag = os.getenv('CIRCLE_TAG')
+        if tag.lstrip('v') != Version:
+            info = "Git tag {0} does not match Tern version {1}".format(
+                tag, Version)
+            sys.exit(info)
 
 
 setup(
-    name="tern",
-    version=Version,
-    author="VMWare Inc",
-    author_email="FIXME@FIXWHAT.THEEMAIL",
-    url="https://github.com/vmware/tern/",
-    description=("An inspection tool to find the OSS compliance metadata of"
-                 " the packages installed in a container image."),
-    long_descrition=_read_long_desc(),
-    long_description_content_type='text/markdown',
-    license="BSD-2.0",
-    keywords="Distribution, Container, Cloud-Native",
-    classifiers=[
-        'Development Status :: 3 - Alpha',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: BSD License',
-        'Natural Language :: English',
-        'Operating System :: POSIX',
-        'Operating System :: POSIX :: Linux',
-        'Operating System :: MacOS :: MacOS X',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: Implementation :: CPython',
-        'Topic :: Software Development'
-    ],
-    include_package_data=True,
-    packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*",
-                                    "tests"]),
-    install_requires=_get_requirements(),
+    setup_requires=['pbr'],
+    pbr=True,
     test_suite="tests.runtests",
-    entry_points={
-        "console_scripts": ["tern = tern.__main__:main"]
-    },
+    cmdclass={
+        "verify": VerifyVersion,
+    }
 )


### PR DESCRIPTION
This commit makes change to package Tern and upload it to PyPI
after each new release version. Specifically, the following
changes are relevant:

1) Add a pypi_deploy job+workflow to config.yml that will only trigger
   on GitHub version tags. The pypi_deploy job installs package
   requirements and creates a ~/.pypirc file with PyPI credentials
   (via circleci private environment variables). The value of these env.
   variables is not accessible by forked repositories but care should be
   taken when merging PRs to check if any forked repositories are
   making changes to .circleci/config.yml in a bad-faith attempt to
   expose their values. pypi_deploy goes on to package tern using
   setup.py and then pushes the package to PyPI using twine.

2) Add a VerifyVersion custom command to setup.py. The VerifyVersion
   command 'verify' is called in .circleci/config.yml to make sure that
   the git tag ($CIRCLE_TAG) matches the version of the project
   according to tern/__init__.py before packaging Tern and pushing to
   PyPI. If not, return a helpful error message that highlights the
   discrepancy between the git tag and Version declared in
   tern/__init__.py and do not push to PyPI.

3) Add a setup.cfg file to utilize the pbr module. The pbr module will
   allow for a cleaner setup.py file and does a lot of the work that
   setup.py was previously doing for us. This commit moves most of the
   code previously in setup.py to an INI-like setup.cfg file and removes
   the custom parsing functions (_read_long_desc() and
   _get_requirements()). Using pbr is preferred for easier and cleaner
   setuptools package management.

Resolves #287
Resolves #211


Signed-off-by: Rose Judge <rjudge@vmware.com>