### PR TITLE
Add a version argument to tern CLI

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -24,6 +24,7 @@ A clear and concise description of what you expected to happen.
 
 **Environment you are running Tern on**
 Enter all that apply
+- Output of 'tern --version'
 - Operating System (Linux Distro and version or Mac or Windows)
 - Vagrant file
 - Container OS

--- a/tern/__main__.py
+++ b/tern/__main__.py
@@ -13,10 +13,13 @@ import argparse
 import importlib
 import logging
 import os
+import sys
 
 from tern.report import report
 from tern.utils import cache
 from tern.utils import constants
+from tern import Version
+
 
 # global logger
 logger = logging.getLogger(constants.logger_name)
@@ -77,6 +80,7 @@ def do_main(args):
 
 def main():
     parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawTextHelpFormatter,
         prog='Tern',
         description='''
            Tern is a container image component curation tool. Tern retrieves
@@ -95,6 +99,11 @@ def main():
                         "Needed when running from within a container")
     parser.add_argument('-r', '--redo', action='store_true',
                         help="Repopulate the cache for found layers")
+    # sys.version gives more information than we care to print
+    py_ver = sys.version.replace('\n', '').split('[')[0]
+    parser.add_argument('-V', '--version', action='version',
+                        version="%(prog)s {0}\n   python version = {1}".format(
+                            Version, py_ver))
     subparsers = parser.add_subparsers(help='Subcommands')
     # subparser for report
     parser_report = subparsers.add_parser('report',


### PR DESCRIPTION
This commit adds a --version option to Tern's CLI. This option will
display the version of Tern that is installed and also output the
python version. This commit also updates the GitHub issue template.
This will be useful for individuals opening bugs to provide the
version of Tern that they are opening the issue against.

Resolves #209

Signed-off-by: Rose Judge <rjudge@vmware.com>