### PR TITLE
Fix vagrant documentation and bootstrap file

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ What the `docker_run.sh` script does is create the directory `workdir` if not pr
 *WARNING:* privileged Docker containers are not secure. DO NOT run this container in production unless you have secured the node (VM or bare metal machine) that the docker daemon is running on.
 
 ## Getting Started with Vagrant<a name="getting-started-with-vagrant">
-Vagrant is a tool to setup an isolated virtual software development environment. If you are using Windows or Mac OSs, this is a good way to get started.
+Vagrant is a tool to setup an isolated virtual software development environment. If you are using Windows or Mac OSes, this is the best way to get started as Tern does not run natively in a Mac OS or Windows environment at this time.
 
 ### Install
 Follow the instructions on the [VirtualBox](https://www.virtualbox.org/wiki/Downloads) website to download VirtualBox on your OS.
@@ -98,13 +98,13 @@ $ vagrant up
 ```
 
 SSH into the created VM: 
- ```
+```
  $ vagrant ssh
- ```
+```
 
 Run the program:
 ```
-$ python -m tern -l report -i debian:buster -f output.txt
+$ python3 -m tern -l report -i debian:buster -f output.txt
 ```
 
 ## Getting Started on Linux<a name="getting-started-on-linux">

--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -25,4 +25,4 @@ sudo usermod -a -G docker vagrant
 
 # Install dependencies
 cd /tern
-pip3 install -r requirements.txt
+pip3 install .


### PR DESCRIPTION
This commit makes two primary changes that enable users to run Tern
with greater ease. Primarily:

1) Updates the README documentation to instruct users to run Tern
   using the 'python3' command instead of 'python'. The vagrant VM OS,
   Ubuntu LTS, links python2.7 to python2 and python3.6 to python3.
   Tern's vagrant/bootstrap.sh file only installs python3 deps and
   therefore, python/python2 is not present on the system. If you
   follow the current directions in README and try to use the python
   command you will see the following error:

  ` Command 'python' not found, but can be installed with:`

   If you use python3, the python 3.6.8 binary runs properly which
   is what we should be telling users unfamiliar with Tern to use.

2) Updates vagrant/bootstrap.sh to pip3 install '.' instead of only the
   requirements.txt packages. When only the requirements were
   installed, the tern command was not recognized in a fresh vagrant
   VM. Using the old bootstrap file, the below error was seen when
   you followed the README directions and ssh'd into a new VM and tried
   to run Tern with python3:

   `/usr/bin/python3: No module named tern`

   If you change the boostrap file to install `pip3 install .` instead
   of only 'requirements.txt', Tern runs without any additional
   configuration steps in the VM environment, which  makes it easier
   for first time users to run Tern.

Lastly, this commit adds a note to the README documentation instructing
Mac OS and Windows users to only run tern in a vagrant VM. Since
tern/tools/fs_hash.sh utilizes Bash commands, it is only able to
run in a Linux environment. If Tern is run Natively on a Mac/Windows
the Bash command in fs_hash.sh won't work properly and Tern will
return with the warning "Cannot retrieve full image metadata"

Resolves #353

Signed-off-by: Rose Judge <rjudge@vmware.com>