### PR TITLE
Fix incorrect reporting when fs_hash.sh fails

### DIFF
--- a/tern/tools/fs_hash.sh
+++ b/tern/tools/fs_hash.sh
@@ -10,6 +10,13 @@
 # extended attributes list
 #
 # repeat for each file
+#
+# Check that all commands to collect metadata exist on the
+# system otherwise exit.
+
+command -v find || { echo "'find' not found on system." >&2 ; exit 1; }
+command -v sha256sum || { echo "'sha256sum' not found on system." >&2 ; exit 1; }
+command -v getfattr || { echo "'getfattr' not found on system." >&2 ; exit 1; }
 
 cwd=`pwd`
 cd $1

--- a/tern/utils/rootfs.py
+++ b/tern/utils/rootfs.py
@@ -56,7 +56,8 @@ def root_command(command, *extra):
                              stderr=subprocess.PIPE)
     result, error = pipes.communicate()  # nosec
     if error:
-        raise subprocess.CalledProcessError(1, cmd=full_cmd, output=error)
+        logger.error("Command failed. %s", error.decode())
+        raise subprocess.CalledProcessError(1, cmd=full_cmd, output=error)  # nosec
     else:
         return result
 


### PR DESCRIPTION
Currently, if there is any failure in the fs_hash.sh script, the only
erro message that gets reported is:
WARNING - report - Cannot retrieve full image metadata.

It is common to see this warning message when attr is not installed in a
Linux environment or if you try to run the script natively on MacOS.
The current error message is not helpful for users trying to understand
the output file.

The following commit adapts the fs_hash.sh script to check for the
availability of the three central commands in the script: find,
sha256sum and getfattr before it runs. If any of these commands are
not available, the script will exit with a more helpful error message.

Finally, tern/utils/rootfs.py was modified to properly log the error
message from pipes.communicate().

Resolves #263

Signed-off-by: Rose Judge <rjudge@vmware.com>