### PR TITLE
Pin requirements only upto the minor version

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,9 +5,9 @@
 -r requirements.txt
 
 # For development work, pull in dev support utilities
-prospector==1.1.6.2
+prospector>=1.1
 # For security linting, use Bandit
-bandit==1.6.0
+bandit~=1.6
 
 # For commit message linting in circleci we need GitPython
-GitPython==2.1.11
+GitPython~=2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 # Please only add direct dependencies here, i.e., do not update with the
-# output of `pip freeze`.  When updating dependency versions, have the
+# output of `pip freeze`.  When updating dependency versions, having the
 # transitive dependencies listed make it more difficult to figure out
 # what should be updated.
 
-PyYAML==5.1
-docker==4.0.1
-requests==2.22.0
+PyYAML>=5.1
+docker~=4.0
+requests~=2.22


### PR DESCRIPTION
For development, in order to be less restrictive on the direct
dependency versions, we only require major and minor versions.

PyYAML - we will allow the latest version if available.
docker - we allow compatible versions.
requests - this is a docker dependency and only used in the code
for catching exceptions. We will allow compatible versions so
it doesn't break the docker API.
prospector - we will allow the latest version if available.
bandit - we will allow compatible versions.
GitPython - this is a bandit dependency. We will allow compatible
versions so it doesn't conflict with bandit.

Resolves #236

Signed-off-by: Nisha K <nishak@vmware.com>