### PR TITLE
Report base OS for image with /etc/os-release

### DIFF
--- a/tern/helpers/common.py
+++ b/tern/helpers/common.py
@@ -424,6 +424,10 @@ def get_os_style(image_layer, binary):
         # We know with high degree of certainty what the OS is
         image_layer.origins.add_notice_to_origins(origin_layer, Notice(
             formats.os_release.format(os_style=get_os_release()), 'info'))
+    elif binary is None:
+        # No binary and no os-release means we have no idea about base OS
+        image_layer.origins.add_notice_to_origins(origin_layer, Notice(
+            errors.no_etc_release, 'warning'))
     else:
         # We make a guess about the OS based on pkg_format + binary
         # First check that binary exists in base.yml
@@ -433,7 +437,7 @@ def get_os_style(image_layer, binary):
                     errors.no_listing_for_base_key.format(listing_key=binary),
                     'warning'))
         else:
-            # Assign image layer attributes
+            # Assign image layer attributes and guess OS
             image_layer.pkg_format = pkg_format
             image_layer.os_guess = os_guess
             image_layer.origins.add_notice_to_origins(origin_layer, Notice(

--- a/tern/report/errors.py
+++ b/tern/report/errors.py
@@ -12,15 +12,18 @@ unrecognized_base = '''Unable to determine the base OS of the image ''' \
 no_packages = '''Unable to recover packages for layer {layer_id}. ''' \
     '''Consider either entering them manually or create a bash script to ''' \
     '''retrieve the package in the command library.\n'''
+no_package_manager = '''Unable to find a known package manager. Cannot ''' \
+    '''list packages.\n'''
+no_etc_release = '''Unknown base OS. Unable to find an os-release file.'''
 no_version = '''No version for package {package_name}. Consider either ''' \
     '''entering the version manually or creating a script to retrieve ''' \
     '''it in the command library\n'''
 no_license = '''No license for package {package_name}. Consider either ''' \
     '''entering the license manually or creating a script to retrieve it ''' \
     '''in the command library\n'''
-no_proj_url = '''No project url for package {package_name}. Consider either ''' \
-    '''entering the source url manually or creating a script to retrieve ''' \
-    '''it in the command library\n'''
+no_proj_url = '''No project url for package {package_name}. Consider ''' \
+    '''either entering the source url manually or creating a script to ''' \
+    '''retrieve it in the command library\n'''
 env_dep_dockerfile = '''Docker build failed: {build_fail_msg} \n Since ''' \
     '''the Docker image cannot be built, Tern will try to retrieve ''' \
     '''package information from the Dockerfile itself.\n'''

--- a/tern/report/report.py
+++ b/tern/report/report.py
@@ -223,11 +223,11 @@ def analyze_docker_image(image_obj, redo=False, dockerfile=False): # pylint: dis
             # unmount proc, sys and dev
             rootfs.undo_mount()
     else:
-        no_base = errors.unrecognized_base.format(
-            image_name=image_obj.name, image_tag=image_obj.tag)
-        logger.warning(no_base)
+        logger.warning(errors.no_package_manager)
+        # /etc/os-release may still be present even if binary is not
+        common.get_os_style(image_obj.layers[0], None)
         image_obj.layers[0].origins.add_notice_to_origins(
-            origin_first_layer, Notice(no_base, 'warning'))
+            origin_first_layer, Notice(errors.no_package_manager, 'warning'))
         # no binary means there is no shell so set to default shell
         logger.warning('Unknown filesystem. Using default shell')
         shell = constants.shell


### PR DESCRIPTION
Currently if an image layer does not have a binary package manager Tern
does not report on the underlying base OS because it assumes that no
package manager means no distro. Generally, this is true but we recently
came across a use case for 'distroless' where there is no package
manager but an /etc/os-release file does exist. This commit will make
two primary changes:

1) Even when there is no binary, check for the existence of an
   /etc/os-release file. If the file is present, report on the findings
   inside.

2) Instead of reporting "Unable to determine the base OS of the image"
   when there is no binary package manager, change the warning message
   to be more accurate -- "Unable to find a known package manager.
   Cannot list packages."

Resolves #366

Signed-off-by: Rose Judge <rjudge@vmware.com>