### PR TITLE
Add git commit sha1 from git repo to -V option

### DIFF
--- a/tern/__main__.py
+++ b/tern/__main__.py
@@ -18,7 +18,7 @@ import sys
 from tern.report import report
 from tern.utils import cache
 from tern.utils import constants
-from tern import Version
+from tern.utils import general
 
 
 # global logger
@@ -56,6 +56,17 @@ def check_format_type(format_type):
     except ModuleNotFoundError:
         raise argparse.ArgumentTypeError('Invalid report formatting type')
     return format_type
+
+
+def get_version():
+    '''Return the version string for the --version command line option'''
+    ver_type, commit_or_ver = general.get_git_rev_or_version()
+    message = ''
+    if ver_type == "package":
+        message = "Tern version {}".format(commit_or_ver)
+    else:
+        message = "Tern at commit {}".format(commit_or_ver)
+    return message
 
 
 def do_main(args):
@@ -102,8 +113,8 @@ def main():
     # sys.version gives more information than we care to print
     py_ver = sys.version.replace('\n', '').split('[')[0]
     parser.add_argument('-V', '--version', action='version',
-                        version="%(prog)s {0}\n   python version = {1}".format(
-                            Version, py_ver))
+                        version="{ver_str}\n   python version = {py_v}".format(
+                            ver_str=get_version(), py_v=py_ver))
     subparsers = parser.add_subparsers(help='Subcommands')
     # subparser for report
     parser_report = subparsers.add_parser('report',


### PR DESCRIPTION
Currently, `tern --version` reports whatever the variable `Version` is in
the code. If a user is working from a git repo, it should report the git
commit sha1 rather than the version as the development branch would have
proceeded beyond the release version and the git commit would be more
relevant.

This commit utilizes an exisitng function in `tern/util/general`,
`get_git_rev_or_version`, and outputs either the static version of Tern or
the latest git commit sha1 if available. Since multiple lines of code
are needed to determine the string that should be outputted to the user
when the --version command line option is called, a new function was
created in `tern/__main__.py` called `get_version()`. This will keep the
parser.add_argument code cleaner and more organized.

Resolves #367

Signed-off-by: Rose Judge <rjudge@vmware.com>