### PR TITLE
Build a binary wheel of the Tern module for PyPI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,11 +73,11 @@ jobs:
       - setup
       - run: pip install .
       - run: pip install twine
+      - run: pip install wheel
       # make sure git tag matches release version
       - run: python setup.py verify
       - create_pypirc 
-      - run: python setup.py sdist
-      - run: twine upload dist/* 
+      - run: python setup.py sdist bdist_wheel upload
 
 workflows:
   version: 2


### PR DESCRIPTION
Instead of packaging Tern for PyPI with only sdist, package with
bdist_wheel. This is preferrable as it will also package the
dependencies. In order to do this, add a line to pip install wheel as
part of the build and release pipeline in .circleci/config.yml.

This commit also adds wheel as a requirement in dev-requirements.txt.
PyYAML automatically builds from source and needs wheel. Adding this
requirement will eliminate developers needing to install wheel
separately from Tern.

Signed-off-by: Rose Judge <rjudge@vmware.com>