### PR TITLE
Add list of direct and transitive dependencies

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -1,0 +1,18 @@
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# This file describes the direct and transitive dependencies for tern
+# It is mostly meant for informational purposes but can be used for
+# automating housekeeping tasks.
+
+tern:
+    - PyYAML
+    - docker:
+      - certifi
+      - chardet
+      - idna
+      - requests
+      - six
+      - urllib3
+      - websocket-client
+


### PR DESCRIPTION
When using pip to list packages that were installed during
development, it is difficult to figure out which dependencies
are direct and which dependencies are transitive. This is
especially difficult for transitive dependencies which we are using
(to catch specific exceptions for example).

We add a yaml file which lists the direct and transitive dependencies
for Tern. The file is in yaml so we can automate updating dependencies
later on.

Resolves #374

Signed-off-by: Nisha K <nishak@vmware.com>