### PR TITLE
ci: Update ubuntu machine everytime

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ executors:
 commands:
   setup:
     steps:
-      - run: sudo apt-get install -y attr
+      - run: sudo apt-get update && sudo apt-get install -y attr
       - checkout
       - run: pyenv global 3.6.5
       - run: pip install --upgrade pip


### PR DESCRIPTION
CircleCI's environment sometimes has it's repositories populated
and sometimes not. When creating a new branch, the spun up VMs
either run apt-get install with no issues or fails because it
cannot find the packages. It is still not known why this happens
on some VMs and not all the VMs. So run apt-get update on all of
them.

Signed-off-by: Nisha K <nishak@vmware.com>