### PR TITLE
ci: TravisCI equivalent tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,13 @@ install:
   - pip install -r dev-requirements.txt
   - pip install .
 
-script:
-  - c=`python ci/evaluate_docs.py`; if [ -z $c ]; then echo "No .py files to lint"; else echo $c | xargs prospector; fi
-  - c=`python ci/evaluate_docs.py`; if [ -z $c ]; then echo "No .py files to lint"; else echo $c | xargs bandit; fi
-  - python ci/test_commit_message.py
-  - python ci/test_files_touched.py
+matrix:
+  include:
+  - name: "Code Style"
+    script: c=`python ci/evaluate_docs.py`; if [ -z $c ]; then echo "No .py files to lint"; else echo $c | xargs prospector; fi
+  - name: "Security Linting"
+    script: c=`python ci/evaluate_docs.py`; if [ -z $c ]; then echo "No .py files to lint"; else echo $c | xargs bandit; fi
+  - name: "Commit Message"
+    script: python ci/test_commit_message.py
+  - name: "Tests"
+    script: python ci/test_files_touched.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+dist: xenial
+
+sudo: true
+
+language: python
+
+python:
+  - "3.6"
+
+services:
+  - docker
+
+before_install:
+  - sudo apt-get install -y attr
+
+install:
+  - pip install -r dev-requirements.txt
+  - pip install .
+
+script:
+  - c=`python ci/evaluate_docs.py`; if [ -z $c ]; then echo "No .py files to lint"; else echo $c | xargs prospector; fi
+  - c=`python ci/evaluate_docs.py`; if [ -z $c ]; then echo "No .py files to lint"; else echo $c | xargs bandit; fi
+  - python ci/test_commit_message.py
+  - python ci/test_files_touched.py

--- a/ci/evaluate_docs.py
+++ b/ci/evaluate_docs.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 from git import Repo
+from git import GitCommandError
 import os
 import sys
 
@@ -14,7 +15,10 @@ import sys
 # of this script is nothing
 
 repo = Repo(os.getcwd())
-repo.git.remote('add', 'upstream', 'git@github.com:vmware/tern.git')
+try:
+    repo.git.remote('add', 'upstream', 'https://github.com/vmware/tern.git')
+except GitCommandError:
+    pass
 repo.git.fetch('upstream')
 
 hcommit = repo.head.commit

--- a/ci/evaluate_docs.py
+++ b/ci/evaluate_docs.py
@@ -8,7 +8,7 @@ from git import GitCommandError
 import os
 import sys
 
-# This is meant to run within circleci
+# This is meant to run within CI Integration
 # Print out only .py files that have changed
 # Pipe to any linting tools
 # Note that some linting tools will lint everything if the output

--- a/ci/test_commit_message.py
+++ b/ci/test_commit_message.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 from git import Repo
+from git import GitCommandError
 import os
 import re
 import sys
@@ -61,10 +62,14 @@ if __name__ == '__main__':
 
     # We are in the 'tern' directory
     repo = Repo(os.getcwd())
-    repo.git.remote('add', 'upstream', 'git@github.com:vmware/tern.git')
+    try:
+        repo.git.remote(
+            'add', 'upstream', 'https://github.com/vmware/tern.git')
+    except GitCommandError:
+        pass
     repo.git.fetch('upstream')
     # Will return commit IDs differentiating HEAD and master
-    commitstr = repo.git.rev_list('HEAD', '^upstream/master')
+    commitstr = repo.git.rev_list('HEAD', '^upstream/master', no_merges=True)
     # If we are on the main project's master branch then there will be no
     # difference and the result will be an empty string
     # So we will not proceed if there is no difference

--- a/ci/test_commit_message.py
+++ b/ci/test_commit_message.py
@@ -9,8 +9,7 @@ import os
 import re
 import sys
 
-# This script is written to be used with circleci and
-# is not meant to be run locally
+# This script is written to be used with CI Integration
 
 
 def lint_commit(commit_id):

--- a/ci/test_files_touched.py
+++ b/ci/test_files_touched.py
@@ -11,7 +11,7 @@ import sys
 import subprocess  # nosec
 
 
-# This script is written to be used with circleci
+# This script is written to be used with CI integration
 
 repo = Repo(os.getcwd())
 try:

--- a/ci/test_files_touched.py
+++ b/ci/test_files_touched.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 from git import Repo
+from git import GitCommandError
 import os
 import re
 import sys
@@ -13,7 +14,10 @@ import subprocess  # nosec
 # This script is written to be used with circleci
 
 repo = Repo(os.getcwd())
-repo.git.remote('add', 'upstream', 'git@github.com:vmware/tern.git')
+try:
+    repo.git.remote('add', 'upstream', 'https://github.com/vmware/tern.git')
+except GitCommandError:
+    pass
 repo.git.fetch('upstream')
 
 hcommit = repo.head.commit
@@ -109,7 +113,7 @@ test_suite = {
 
 alltests = []
 for change in changes:
-    for check in test_suite.keys():
+    for check, _ in test_suite.items():
         if check.match(change):
             alltests.extend(test_suite[check])
 


### PR DESCRIPTION
Falling back on TravisCI in case CircleCI doesn't pan out.

- Added a .travis.yml file with tests just for PRs
- Modified the tests so they don't fail when a remote named
'upstream' is already present

Signed-off-by: Nisha K <nishak@vmware.com>