### PR TITLE
tools: Added requirements.in file

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,0 +1,11 @@
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# This file is used by pip-tools for release management
+#
+# Please only add direct dependencies here, i.e., do not update with the
+# output of `pip freeze`.
+
+PyYAML
+docker
+requests


### PR DESCRIPTION
pip-tools is used to manage direct and transitive dependencies
for python projects. We are using it here for 2 reasons:

1. To check for updates
2. To generate a frozen requirements.txt file for releases

We are not following the recommended workflow proposed by pip-tools
because it does not take into account downstream packagers who may
want looser restrictions on the dependency versions.

To avoid mistakes in committing changes to requirements.txt that
pip-compile automatically creates, we will not add pip-tools as a
development tool and instead only use it when the maintainers are
cutting a release or checking for updates.

There are purposefully no versions in the requirements.in file
so checking and testing updates is unhindered.

Signed-off-by: Nisha K <nishak@vmware.com>