### PR TITLE
docs: Use pip-tools when cutting a release

### DIFF
--- a/docs/releases/release_checklist.md
+++ b/docs/releases/release_checklist.md
@@ -2,16 +2,21 @@
 
 This is a checklist for cutting a release
 
-[ ] Update direct dependencies and run tests
-* Create a fresh environment.
-* Pip install wheel.
-* Pip install each of the first level dependencies listed in the dependencies.yml file.
-* Do pip freeze and check the major and minor versions for all the dependencies in the requirements.txt file.
-* Update the requirements.txt file in the development environment for tern.
-* Pip uninstall tern and then reinstall tern. Run the tests. Rollback dependencies if needed.
-* Copy output of pip freeze to `tern/docs/releases/v<release>-vendor.txt`
+[checkbox:unchecked] Prepare Release PR.
+* Freeze development on master.
+* Create a fresh environment and activate it.
+* Clone this repository.
+* Create a PR branch for the release.
 
-[ ] Write release notes
+[checkbox:unchecked] Update direct dependencies and run tests.
+* Run `pip install wheel pip-tools`.
+* Run `pip-compile`. This will overwrite `requirements.txt`.
+* Run `pip install .` to install tern.
+* Run appropriate tests. Roll back requirements if necessary.
+* When satisfied, copy `requirements.txt` to  `tern/docs/releases/v<release>-requirements.txt`
+* Run `git checkout -- requirements.txt` to undo pip-compile's overwrite. Update major and minor dependencies.
+
+[checkbox:unchecked] Write release notes.
 * Summary
 * New Features (if any)
 * Deprecated Features (if any)
@@ -27,11 +32,11 @@ Changelog produced by command: `git log --pretty=format:"%h %s" v0.3.0..master`
 * Contributors (look at Authors in the changelog `git log --pretty=format:"%an %ae" v0.3.0..master | uniq`)
 * Contact the Maintainers
 
-[ ] Commit release notes and any dependency file changes.
+[checkbox:unchecked] Commit release notes, `v<release>-requirements.txt`, and any changes to `requirements.txt`.
 
-[ ] Tag release on GitHub. Check to see if release automation works.
+[checkbox:unchecked] Tag release on GitHub. Check to see if release automation works.
 
-[ ] Test pip package
+[checkbox:unchecked] Test pip package.
 * Create a fresh environment.
 * Pip install tern.
-* Run tests.
+* Run appropriate tests.


### PR DESCRIPTION
- Modified the check for updating direct dependencies using pip-tools
and recording the frozen requirements.txt file in the releases. So, if
we wanted to recreate the release, we would:
    1. Checkout the release tag
    2. Replace the requirements.txt file with the
release-requirements.txt file
    3. Run `python setup.py sdist bdist_wheel`
    4. Run `pip install tern-etc-etc.whl`
This isn't a bit-by-bit recreation but it makes the release build
somewhat repeatable.
- Modified the markdown checkboxes.
- Some sentence structure corrections and some more tests for clarity

Resolves #388

Signed-off-by: Nisha K <nishak@vmware.com>