### PR TITLE
classes: Removed unnecessary pass

### DIFF
--- a/tern/classes/template.py
+++ b/tern/classes/template.py
@@ -23,26 +23,20 @@ class Template(metaclass=ABCMeta):
     @abstractmethod
     def package(self):
         '''Must implement a mapping for 'Package' class properties'''
-        pass
 
     @abstractmethod
     def image_layer(self):
         '''Must implement a mapping for 'ImageLayer' class properties'''
-        pass
 
     @abstractmethod
     def image(self):
         '''Must implement a mapping for 'Image' class properties'''
-        pass
 
     def notice(self):
         '''Should implement a mapping for 'Notice' class properties'''
-        pass
 
     def notice_origin(self):
         '''Should implement a mapping for 'NoticeOrigin' class properties'''
-        pass
 
     def origins(self):
         '''Should implement a mapping for 'Origins' class properties'''
-        pass

--- a/tests/test_class_template.py
+++ b/tests/test_class_template.py
@@ -25,7 +25,7 @@ class TestClassTemplate(unittest.TestCase):
         mapping = self.template1.package()
         self.assertEqual(mapping['name'], 'package.name')
         self.assertEqual(mapping['version'], 'package.version')
-        self.assertEqual(mapping['pkg_license'], 'package.pkg_license')
+        self.assertEqual(mapping['pkg_license'], 'package.license')
 
     def testImageLayer(self):
         mapping = self.template1.image_layer()


### PR DESCRIPTION
Prospector complains of unnecessary pass in empty abstract
methods.

The test for the package mapping asserts an invalid string that
doesn't match what is in the test fixture. Changing the string
to the right one.

Signed-off-by: Nisha K <nishak@vmware.com>