### PR TITLE
circleci: Change mirrors that test machine pulls from

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,11 @@ executors:
 commands:
   setup:
     steps:
+      - run: |
+         sudo rm /etc/apt/sources.list
+         echo "deb http://ubuntu.mirror.constant.com/ xenial main" | sudo tee -a /etc/apt/sources.list
+         echo "deb-src http://ubuntu.mirror.constant.com/ xenial main" | sudo tee -a /etc/apt/sources.list
+         sudo apt-get update
       - run: sudo apt-get install -y attr
       - checkout
       - run: pyenv global 3.6.5


### PR DESCRIPTION
circleci: Change mirrors to prevent test failures

Try the "change mirrors" suggestion in the following circleci
article as it seems to address the issue we were seeing with circleci
not being able to update the attr dependency properly on the test VM.

https://support.circleci.com/hc/en-us/articles/
360021256633-Apt-Get-Update-Is-Slow-Or-Locked

Using the constant ubuntu xenial mirror.

For the record, the issue we were seeing consistently for every test
ran was:


```
#!/bin/bash -eo pipefail
sudo apt-get install -y attr

Reading package lists... Done


Building dependency tree


Reading state information... Done

Package attr is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

E: Package 'attr' has no installation candidate
Exited with code 100
```


Signed-off-by: Rose Judge <rjudge@vmware.com>