### PR TITLE
ci/cd: Add a pre-deploy to use release reqs file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,11 @@ commands:
            echo -e "[pypi]" >> ~/.pypirc
            echo -e "username = $R_PYPI_UN" >> ~/.pypirc
            echo -e "password = $PYPI_PW" >> ~/.pypiruc
+  pre_deploy:
+    steps:
+      - run:
+          name: Ensure that PyPI packages Tern with the same requirements used when the release was cut
+          command: cp docs/releases/${CIRCLE_TAG//./_}-requirements.txt requirements.txt
 
 jobs:
   # linting using Prospector
@@ -77,6 +82,7 @@ jobs:
    steps:
       - setup
       - run: pip install .
+      - pre_deploy
       - run: pip install twine
       - run: pip install wheel
       # make sure git tag matches release version


### PR DESCRIPTION
When we cut a release for Tern, we gather the direct and transient
dependencies via pip-compile. We copy the output of this command
to `docs/releases/vx_x_x-requirements.txt` in order to maintain
reproducibility for the future. However, when we build and release the
Tern PyPI package there is a chance that the requirements may change
between when we cut the release and when we build and release the
package to PyPI since the official requirements.txt does not pin to
exact versions and only lists the direct dependencies.

This commit adds a step to the deploy process that copies the
`docs/releases/vx_x_x-requirements.txt` file to `requirements.txt` so that
pbr and PyPI will package Tern using the same requirements recorded
when the release was cut.

Resolves #389

Signed-off-by: Rose Judge <rjudge@vmware.com>