### PR TITLE
docs: update README to call yaml report correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ $ tern report -m json -i golang:1.12-alpine
 ## YAML Format<a name="report-yaml">
 You can get the results in a YAML file to be consumed by a downstream tool or script.
 ```
-$ tern -l report -y -i golang:1.12-alpine -f output.yaml
+$ tern -l report -m yaml -i golang:1.12-alpine -f output.yaml
 ```
 
 ## SPDX tag-value Format<a name="report-spdxtagvalue">


### PR DESCRIPTION
A previous commit, 912bb99, deprecated the -y and --yaml option on the tern
command line. Instead, you should call the json report format using the
'report -m yaml' command line option. This commit makes a simple change
to the README documentation to reflect the updated command line
notation.

Signed-off-by: Rose Judge <rjudge@vmware.com>