### PR TITLE
fix: Remove hardcoded version string

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ PyYAML>=5.1
 docker~=4.0
 requests~=2.22
 stevedore>=1.30
+pbr>=5.4

--- a/setup.py
+++ b/setup.py
@@ -4,31 +4,11 @@
 # Copyright (c) 2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
-import os
-import sys
-
-from tern import Version
-from setuptools.command.install import install
 from setuptools import setup
-
-
-class VerifyVersion(install):
-    """Run a custom verify command"""
-    description = "Verify that the git tag matches current release version."
-
-    def run(self):
-        tag = os.getenv('CIRCLE_TAG')
-        if tag.lstrip('v') != Version:
-            info = "Git tag {0} does not match Tern version {1}".format(
-                tag, Version)
-            sys.exit(info)
 
 
 setup(
     setup_requires=['pbr'],
     pbr=True,
     test_suite="tests.runtests",
-    cmdclass={
-        "verify": VerifyVersion,
-    }
 )

--- a/tern/__init__.py
+++ b/tern/__init__.py
@@ -2,5 +2,3 @@
 #
 # Copyright (c) 2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
-
-Version = "0.4.0"

--- a/tern/report/content.py
+++ b/tern/report/content.py
@@ -10,7 +10,6 @@ Functions to generate content for the report
 from tern.command_lib import command_lib
 from tern.report import formats
 from tern.utils.general import get_git_rev_or_version
-from tern import Version
 
 
 def get_tool_version():
@@ -18,7 +17,7 @@ def get_tool_version():
     ver_type, ver = get_git_rev_or_version()
     if ver_type == 'commit':
         return formats.commit_version.format(commit_sha=ver)
-    return formats.packaged_version.format(version=Version)
+    return formats.packaged_version.format(version=ver)
 
 
 def print_invoke_list(info_dict, info):

--- a/tern/utils/general.py
+++ b/tern/utils/general.py
@@ -9,7 +9,7 @@ import re
 import subprocess  # nosec
 from contextlib import contextmanager
 
-from tern import Version
+from pbr.version import VersionInfo
 from tern.utils import constants
 
 
@@ -91,18 +91,19 @@ def parse_command(command):
 
 
 def get_git_rev_or_version():
-    '''Assuming we are operating within a git repository, get the SHA
-    of the current commit'''
+    '''Either get the current git commit or the PyPI distribution
+    Use pbr to get the package version'''
     command = ['git', 'rev-parse', 'HEAD']
     try:
-        output = subprocess.check_output(command)  # nosec
+        output = subprocess.check_output(  # nosec
+            command, stderr=subprocess.DEVNULL)
         if isinstance(output, bytes):
             output = output.decode('utf-8')
         ver_type = 'commit'
 
     except subprocess.CalledProcessError:
         ver_type = 'package'
-        output = Version
+        output = VersionInfo('tern').version_string()
     return ver_type, output.split('\n').pop(0)
 
 


### PR DESCRIPTION
We use a hardcoded version string which may not match the package
version produced by pbr. Since pbr handles the versioning for us
based on tags, every time we tag a release, pbr will create a
version string. We can now use that version string to report out
what version of tern we are running.

We report out the tern version in a number of places:
- It's used in the generated report itself
- It's used when running `tern --version`

In order to be consistent in all these places, we rely on pbr to
report the version in the general purpose get_git_rev_or_version
function. Then we use that function in the report content
generation and in `tern --version`

Now that we have a common way of getting the version, we remove
the VerifyVersion function in setup.py and the hardcoded Version
string in the __init__.py in the source code root.

We finally add pbr as a requirement for installation.

Signed-off-by: Nisha K <nishak@vmware.com>