### PR TITLE
ci/cd: Stop prospector errors for imports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,7 @@ jobs:
     steps:
       - setup
       - run: pip install prospector>=1.1 GitPython~=2.1
+      - run: pip install .
       - run: c=`python ci/evaluate_docs.py`; if [ -z $c ]; then echo "No .py files to lint"; else echo $c | xargs prospector; fi
   # security linting using Bandit
   security:


### PR DESCRIPTION
Prospector checks to see if it can import all the modules specified
in a python file which is a nice check. However, because of this,
it will complain if the project's dependencies are not installed.
So we will install them before running prospector.

Signed-off-by: Nisha K <nishak@vmware.com>