### PR TITLE
Allow Tern to pull by digest

### DIFF
--- a/tern/__main__.py
+++ b/tern/__main__.py
@@ -113,7 +113,10 @@ def main():
                                " image")
     parser_report.add_argument('-i', '--docker-image',
                                help="Docker image that exists locally -"
-                               " image:tag")
+                               " image:tag"
+                               " The option can be used to pull docker"
+                               " images by digest as well -"
+                               " <repo>@<digest-type>:<digest>")
     parser_report.add_argument('-s', '--summary', action='store_true',
                                help="Summarize the report as a list of"
                                " packages with associated information")


### PR DESCRIPTION
Tern actually has the functionality to pull by digest, but it is not evident as the docker python api does not explicitly specify it.

Resolves https://github.com/vmware/tern/issues/418

Signed-off-by: Prajwal M <prajwalmmath@gmail.com>