### PR TITLE
docs: Updates based on current project status

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ Maintainers are people with lives of their own. The typical time to get a respon
 
 **Project Maintainers**
 - @nishakm
-- @tpepper
+- @rnjudge
 
 ## Other Communication Channels
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ Tern gives you a deeper understanding of your container's bill of materials so y
 
 
 # Getting Started<a name="getting-started"/>
-Tern is not distributed on PyPI or as Docker images yet. This is coming soon. See the [Project Status](#project-status) for details.
 
 ## Getting Started with Docker<a name="getting-started-with-docker">
 Docker is the most widely used tool to build and run containers. If you already have Docker installed, you can run Tern by building a container with the Dockerfile provided and the `docker_run.sh` script:
@@ -75,6 +74,8 @@ What the `docker_run.sh` script does is create the directory `workdir` if not pr
 
 *WARNING:* privileged Docker containers are not secure. DO NOT run this container in production unless you have secured the node (VM or bare metal machine) that the docker daemon is running on.
 
+Tern is not distributed as Docker images yet. This is coming soon. Watch the [Project Status](#project-status) for updates.
+
 ## Getting Started with Vagrant<a name="getting-started-with-vagrant">
 Vagrant is a tool to setup an isolated virtual software development environment. If you are using Windows or Mac OSes, this is the best way to get started as Tern does not run natively in a Mac OS or Windows environment at this time.
 
@@ -99,12 +100,12 @@ $ vagrant up
 
 SSH into the created VM: 
 ```
- $ vagrant ssh
+$ vagrant ssh
 ```
 
-Run the program:
+Run:
 ```
-$ python3 -m tern -l report -i debian:buster -f output.txt
+$ tern -l report -i debian:buster -f output.txt
 ```
 
 ## Getting Started on Linux<a name="getting-started-on-linux">
@@ -113,14 +114,14 @@ If you have a Linux OS you will need a distro with a kernel version >= 4.0 (Ubun
 - Git (Installation instructions can be found here: https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 - attr (sudo apt-get install attr or sudo dnf install attr)
 - Python 3.6 or newer (sudo apt-get install python3.6(3.7) or sudo dnf install python36(37))
-- Pip (sudo apt-get install python3-pip). Note that you don't have to do this for Fedora OSs.
+- Pip (sudo apt-get install python3-pip).
+
+Some distro versions have all of these except `attr` preinstalled but `attr` is a common utility and is available via the package manager.
 
 For Docker containers
 - Docker CE (Installation instructions can be found here: https://docs.docker.com/engine/installation/#server)
 
 Make sure the docker daemon is running.
-
-*NOTE:* Tern currently supports containers built with Docker but it is architected to support other container image formats.
 
 Create a python3 virtual environment:
 ```
@@ -130,20 +131,14 @@ $ cd ternenv
 
 *NOTE:* Your OS might distribute each Python version separately. For example, on Ubuntu LTS, Python 2.7 is linked to `python2` and Python 3.6 is linked to `python3`. I develop with Python 3.7 which is installed separately with no symlinks. In this case, I use the binary. The binaries are usually installed in `/usr/bin/python`.
 
-Clone this repository:
-```
-$ git clone https://github.com/vmware/tern.git
-```
-
 Activate the virtual environment:
 ```
 $ source bin/activate
 ```
 
-Install requirements:
+Install tern:
 ```
-$ cd tern
-$ pip install .
+$ pip install tern
 ```
 
 Run Tern:
@@ -152,6 +147,8 @@ $ tern -l report -f output.txt -i debian:buster
 ```
 
 # Using Tern<a name="using-tern">
+
+*WARNING*: The CLI has changed since the last release. Visit [Tern's PyPI project page](https://pypi.org/project/tern/) to find the correct CLI options or just run `tern -h`.
 
 Tern creates a report containing the Bill of Materials (BoM) of a container image, including notes about how it collects this information, and files for which it has no information about. Currently, Tern supports only containers built using Docker. This is the most ubiquitous type of container image that exists so the project started with a focus on those. However, it is architected to support other images that closely follow the [OCI image spec](https://github.com/opencontainers/image-spec/blob/master/spec.md).
 
@@ -212,17 +209,20 @@ $ python tests/<test file>.py
 ```
 
 ## Project Status<a name="project-status"/>
-Release 0.4.0 is here!
+Release 0.5.4 is here!
 
-See the [release notes](docs/releases/v0_4_0.md) for more information.
+See the [release notes](docs/releases/v0_5_0.md) for more information. See the [update notes](docs/releases/v0_5_4.md) for patches on top of this release.
 
-We try to keep the [project roadmap](./docs/project-roadmap.md) as up to date as possible. We are currently working on Release 0.5.0
+We try to keep the [project roadmap](./docs/project-roadmap.md) as up to date as possible. We are currently working on Release 1.0.0.
+
+Somewhere along the line of development, we accidentally rewrote git history on the master branch. Some merge commits are gone but the commits that have all the changes and the tags are still there. We're truly sorry about this mistake and we are working on ways in which we, the ones with admin privileges on the project, will not shoot ourselves in the foot again.
 
 ## Releases
-* [v0.1.0](docs/releases/v0_1_0.md)
-* [v0.2.0](docs/releases/v0_2_0.md)
-* [v0.3.0](docs/releases/v0_3_0.md)
+* [v0.5.4](docs/releases/v0_5_4.md)
 * [v0.4.0](docs/releases/v0_4_0.md)
+* [v0.3.0](docs/releases/v0_3_0.md)
+* [v0.2.0](docs/releases/v0_2_0.md)
+* [v0.1.0](docs/releases/v0_1_0.md)
 
 ## Documentation<a name="documentation"/>
 Architecture, function blocks, code descriptions and the project roadmap are located in the docs folder. Contributions to the documentation are welcome! See the [contributing guide](/CONTRIBUTING.md) to find out how to submit changes.

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -2,20 +2,25 @@
 
 ## 2019
 
-Since 2018, Tern has [joined the Linux Foundation](https://www.linuxfoundation.org/press-release/2018/12/the-linux-foundation-to-launch-new-tooling-project-to-improve-open-source-compliance/). As a result, many of the project's goals will be aligned with the goals of the ACT project. This basically means some more resources will go towards making the project easier for developers to use while *gently* motivating them to follow some best practices. With that in mind, we will be focusing on the [SPDX superbug](https://github.com/vmware/tern/issues/174) for release 0.4.0 slated for May of 2019.
+Since 2018, Tern has [joined the Linux Foundation](https://www.linuxfoundation.org/press-release/2018/12/the-linux-foundation-to-launch-new-tooling-project-to-improve-open-source-compliance/). As a result, many of the project's goals will be aligned with the goals of the ACT project. This basically means some more resources will go towards making the project easier for developers to use while *gently* motivating them to follow some best practices. We will also be focusing on allowing Tern to better integrate with these and other projects.
 
-CI/CD for the project has now become a priority. We can't sustain further community growth without it. So for release 0.5.0 slated for August of 2019, we will focus on these items:
+For Release 0.4.0 dated May 2019, we will be focusing on the [SPDX superbug](https://github.com/vmware/tern/issues/174).
+
+CI/CD for the project became a priority. We can't sustain further community growth without it. So for release 0.5.4 dated August 2019, we focused on these items:
 
 - Setting up Circle CI to run linting with Prospector
-- Setting up a Build and Release pipeline where PyPI package managers and Dockerhub container images can be distributed
+- Setting up a Build and Release pipeline where PyPI package managers
 - Setting up Circle CI to run tests based on files touched
 
-This might turn into a small release as I am on vacation for most of the month of July. However I will do some backlog scrubbing and some of these items might be included:
+This was a relatively small release as one of the maintainers was on vacation in July.
 
-- Using the [stevedore](https://github.com/openstack/stevedore) module to dynamically load templates.
-- Some refactoring to lay the groundwork for enabling language level package managers.
+For Release 1.0.0 slated for November of 2019, we will focus on the following:
 
-We will then be ready to focus on enabling our first language level package manager - pip. We also have a bunch of technical debt to tackle. So we will focus on these for release 0.6.0 slated for November of 2019.
+- Using the [stevedore](https://github.com/openstack/stevedore) module to dynamically load reporting formats.
+- Some refactoring to allow external tools to be integrated into Tern.
+- Some refactoring to allow containers built using other tools. This includes enabling Tern to use a raw container image tarball.
+- Some refactoring to allow language level package managers. We will focus on pip
+- Bug fixes and technical debt.
 
 This timetable is based on time, resources and feedback from you and will change accordingly.
 

--- a/docs/releases/v0_5_4.md
+++ b/docs/releases/v0_5_4.md
@@ -5,9 +5,11 @@ Please see the [Release 0.5.0 release notes](v0_5_0.md) for details on the first
 Patches on top of v0.5.0 involve fixing our deployment pipeline.
 
 ## Patches
+```
 6607e82 docs: Release notes for release 0.5.3
 a12fe9c ci/cd: Update description key in setup.cfg
 74cc9fb docs: Release notes for release 0.5.2
 ee99d6a ci/cd: Fix typo in pypirc file
 6db943d docs: Release notes for release 0.5.1
 28d7683 ci/cd: Remove 'verify' custom command
+```

--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -23,6 +23,5 @@ sudo apt-get install -y docker.io
 
 sudo usermod -a -G docker vagrant
 
-# Install dependencies
-cd /tern
-pip3 install .
+# Install tern
+pip3 install tern


### PR DESCRIPTION
- Modified the list of project maintainers.
- Modified the "Getting Started" section to incorporate the now
available PyPI package.
- Made some mention in the README that most linux distros have
all the requirements except for attr which needs to be installed
separately.
- Removed general purpose statement that tern is architected to
use other container images besides Docker. At this point this is
not the case.
- Added a warning that the CLI has changed since the last release
and provided a link to the PyPI project page for instructions.
- Updated the project status.
- Changed the order of the releases to be latest first.
- Added release 0.5.4.
- Updated the project roadmap with past accomplishments and future
work.
- Updated the vagrant bootstrap script to just install tern. The
project clone is still in its original spot so the vagrant box
can still be used as a development environment.

Signed-off-by: Nisha K <nishak@vmware.com>