### PR TITLE
spdx: Handle reporting for empty license metadata

### DIFF
--- a/tern/classes/package.py
+++ b/tern/classes/package.py
@@ -155,9 +155,3 @@ class Package:
             if value != other_pkg_dict[key]:
                 return False
         return True
-
-    def get_package_id(self):
-        '''This method returns a string of the name and version for a package
-        represented as "name.version". This method might be helpful when working
-        with SPDX documents that require a unique package identifier.'''
-        return "{0}.{1}".format(self.name, self.version)

--- a/tern/formats/spdx/formats.py
+++ b/tern/formats/spdx/formats.py
@@ -9,6 +9,7 @@ SPDX document formatting
 
 # basic strings
 tag_value = '{tag}: {value}'
+block_text = '<text>{message}</text>'
 
 # document level strings
 spdx_version = 'SPDXVersion: SPDX-2.1'
@@ -25,6 +26,7 @@ created = 'Created: {timestamp}'
 
 # Package level strings
 package_comment = 'PackageComment: <text>{comment}</text>'
+package_id = '{name}-{ver}'
 
 # Relationship strings
 contains = 'Relationship: {outer} CONTAINS {inner}'

--- a/tests/test_class_package.py
+++ b/tests/test_class_package.py
@@ -121,9 +121,6 @@ class TestClassPackage(unittest.TestCase):
         self.assertEqual(p.origins.origins[0].notices[2].message,
                          "No metadata for key: download_url")
 
-    def testGetPackageId(self):
-        self.assertEqual(self.p1.get_package_id(), 'p1.1.0')
-
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Currently, if no license metadata is found (i.e. debian-based images)
Tern does not generate valid SPDX. An empty license field still reports
as "LicenseRef-". According to the 2.1 spec, if information about the
license is unknown, the value should be NOASSERTION.

This commit adds a few checks in
tern/formats/spdx/spdxtagvalue/generator.py to make sure that a license
value exists before trying to report the license information.

It also moves the get_package_id functionality originally in
tern/classes/package.py to a format in tern/formats/spdx/formats.py as
package_id is a value only utilized by SPDX format reports. Since
the get_package_id functionality was moved out of classes, the test for
this function was removed from the test_class_package test file.

tern/formats/spdx/spdxtagvalue/generator.py was updated to pull the
package_id info from spdx formats.py and has additional manipulation
to handle the case when a debian package is reported in the form
[epoch:]upstream_version[-debian_revision]. The colon after the epoch
needs to be changed to '-' in order to validate the SPDX report.

Additionally, this commit wraps the PackageCopyrightText value in
<text></text> in the case that the copyright statement is more than one
line per guidelines from the 2.1 spec.

Finally, this commit makes a change to the logic inside
update_license_list() that gets rid of the dangling license block at
the end of the report if no licenses are available from the container
image metadata.

Resolves #431

Signed-off-by: Rose Judge <rjudge@vmware.com>