### PR TITLE
classes: Changed separator for package id

### DIFF
--- a/tern/classes/package.py
+++ b/tern/classes/package.py
@@ -88,7 +88,7 @@ class Package:
 
     @checksum.setter
     def checksum(self, checksum):
-        self.__checksum = checksum;
+        self.__checksum = checksum
 
     def to_dict(self, template=None):
         '''Return a dictionary version of the Package object
@@ -158,6 +158,7 @@ class Package:
 
     def get_package_id(self):
         '''This method returns a string of the name and version for a package
-        represented as "name.version". This method might be helpful when working
-        with SPDX documents that require a unique package identifier.'''
-        return "{0}.{1}".format(self.name, self.version)
+        represented as "name.version". This method might be helpful when
+        working with SPDX documents that require a unique package
+        identifier.'''
+        return "{0}-{1}".format(self.name, self.version)

--- a/tests/test_class_package.py
+++ b/tests/test_class_package.py
@@ -122,7 +122,7 @@ class TestClassPackage(unittest.TestCase):
                          "No metadata for key: download_url")
 
     def testGetPackageId(self):
-        self.assertEqual(self.p1.get_package_id(), 'p1.1.0')
+        self.assertEqual(self.p1.get_package_id(), 'p1-1.0')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When reading the package id, it is sometimes hard to distinguish
between the package name and the package version, especially if
the package version is of the Debian form:
[epoch:]upstream_version[-debian_revision]

- Replaced the separator '.' with '-'.
- Adjusted the unit test for the Package class accordingly
- Removed stray semicolon
- Shortened description line to less than 80 characters

Signed-off-by: Nisha K <nishak@vmware.com>