### PR TITLE
cli: Update "report" help info to be more useful

### DIFF
--- a/tern/__main__.py
+++ b/tern/__main__.py
@@ -107,7 +107,9 @@ def main():
     subparsers = parser.add_subparsers(help='Subcommands')
     # subparser for report
     parser_report = subparsers.add_parser('report',
-                                          help="Create a report")
+                                          help="Create a BoM report."
+                                          " Run 'tern report -h' for"
+                                          " format options.")
     parser_report.add_argument('-d', '--dockerfile', type=check_file_existence,
                                help="Dockerfile used to build the Docker"
                                " image")


### PR DESCRIPTION
The current 'tern -h' output does not contain any information about
the types of reports available to generate. This is because the report
formats are part of a subparser which does not display by default. This
commit adds information that points the user to a command they can use
to  display the report format types.

Signed-off-by: Rose Judge <rjudge@vmware.com>