### PR TITLE
Create default report plugin and deprecate verbose

### DIFF
--- a/ci/test_files_touched.py
+++ b/ci/test_files_touched.py
@@ -77,7 +77,6 @@ test_suite = {
     re.compile('tern/report'): [
         'tern -l report -i golang:alpine',
         'tern -l report -f yaml -i photon:3.0',
-        'tern -l report -s -i photon:3.0',
         'tern -l report -f json -i photon:3.0',
         'tern -l report -f spdxtagvalue -i photon:3.0',
         'tern -l report -d samples/alpine_python/Dockerfile'],

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ include_package_data = True
 
 [entry_points]
 tern.formats =
+    default = tern.formats.default.generator:Default
     spdxtagvalue = tern.formats.spdx.spdxtagvalue.generator:SpdxTagValue
     json = tern.formats.json.generator:JSON
     yaml = tern.formats.yaml.generator:YAML

--- a/tern/__main__.py
+++ b/tern/__main__.py
@@ -119,9 +119,6 @@ def main():
                                " The option can be used to pull docker"
                                " images by digest as well -"
                                " <repo>@<digest-type>:<digest>")
-    parser_report.add_argument('-s', '--summary', action='store_true',
-                               help="Summarize the report as a list of"
-                               " packages with associated information")
     parser_report.add_argument('-f', '--report-format',
                                metavar='REPORT_FORMAT',
                                help="Format the report using one of the "

--- a/tern/formats/default/__init__.py
+++ b/tern/formats/default/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause

--- a/tern/formats/default/generator.py
+++ b/tern/formats/default/generator.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""
+default report generator
+"""
+
+import logging
+
+from tern.report import formats
+from tern.formats import generator
+from tern.report import content
+from tern.utils import constants
+
+
+# global logger
+logger = logging.getLogger(constants.logger_name)
+
+
+def print_full_report(image):
+    '''Given an image, go through the Origins object and collect all the
+    notices for the image, layers and packages'''
+    notes = ''
+    pkg_list = []
+    license_list = []
+    for image_origin in image.origins.origins:
+        notes = notes + content.print_notices(image_origin, '', '\t')
+    for layer in image.layers:
+        if layer.import_image:
+            notes = notes + print_full_report(layer.import_image)
+        else:
+            for layer_origin in layer.origins.origins:
+                notes = notes + content.print_notices(layer_origin,
+                                                      '\t', '\t\t')
+            for package in layer.packages:
+                pkg = package.name + "-" + package.version
+                if pkg not in pkg_list and pkg:
+                    pkg_list.append(pkg)
+                if package.pkg_license not in license_list and \
+                        package.pkg_license:
+                    license_list.append(package.pkg_license)
+            notes = notes + formats.package_demarkation
+    packages = formats.packages_list.format(list=", ".join(pkg_list) if
+                                            pkg_list else 'None')
+    licenses = formats.licenses_list.format(list=", ".join(license_list) if
+                                            license_list else 'None')
+    return notes + packages + formats.package_demarkation + licenses
+
+
+class Default(generator.Generate):
+    def generate(self, image_obj_list):
+        '''Generate a default report'''
+        report = formats.disclaimer.format(
+            version_info=content.get_tool_version())
+        logger.debug('Creating a detailed report of components in image...')
+        for image in image_obj_list:
+            report = report + print_full_report(image)
+        return report

--- a/tern/report/content.py
+++ b/tern/report/content.py
@@ -69,23 +69,6 @@ def print_package_invoke(command_name):
     return report
 
 
-def print_package(pkg_obj, prefix):
-    '''Given a Package object, print out information with a prefix'''
-    notes = formats.package_demarkation
-    notes = notes + prefix + formats.package_name.format(
-        package_name=pkg_obj.name)
-    notes = notes + prefix + formats.package_version.format(
-        package_version=pkg_obj.version)
-    notes = notes + prefix + formats.package_url.format(
-        package_url=pkg_obj.proj_url)
-    notes = notes + prefix + formats.package_license.format(
-        package_license=pkg_obj.pkg_license)
-    notes = notes + prefix + formats.package_copyright.format(
-        package_copyright=pkg_obj.copyright)
-    notes = notes + '\n\n'
-    return notes
-
-
 def print_notices(notice_origin, origin_pfx, notice_pfx):
     '''Given a NoticeOrigin object with a prefix (like a series of tabs)
     for the origin and the notice messages, return the notes'''
@@ -93,38 +76,4 @@ def print_notices(notice_origin, origin_pfx, notice_pfx):
     for notice in notice_origin.notices:
         notes = notes + notice_pfx + notice.level + ': ' + \
             notice.message + '\n'
-    return notes
-
-
-def print_full_report(image):
-    '''Given an image, go through the Origins object and collect all the
-    notices for the image, layers and packages'''
-    notes = ''
-    for image_origin in image.origins.origins:
-        notes = notes + print_notices(image_origin, '', '\t')
-    for layer in image.layers:
-        if layer.import_image:
-            notes = notes + print_full_report(layer.import_image)
-        else:
-            for layer_origin in layer.origins.origins:
-                notes = notes + print_notices(layer_origin, '\t', '\t\t')
-            for package in layer.packages:
-                notes = notes + print_package(package, '\t\t')
-                for package_origin in package.origins.origins:
-                    notes = notes + print_notices(
-                        package_origin, '\t\t', '\t\t\t')
-            notes = notes + formats.package_demarkation
-    return notes
-
-
-def print_summary_report(image):
-    '''Given an image, only print the package information'''
-    notes = ''
-    for layer in image.layers:
-        if layer.import_image:
-            notes = notes + print_summary_report(layer.import_image)
-        else:
-            for package in layer.packages:
-                notes = notes + print_package(package, '')
-            notes = notes + formats.package_demarkation
     return notes

--- a/tern/report/formats.py
+++ b/tern/report/formats.py
@@ -43,6 +43,9 @@ package_version = '''Version: {package_version}\n'''
 package_url = '''Project URL: {package_url}\n'''
 package_license = '''License: {package_license}\n'''
 package_copyright = '''Copyright Text: {package_copyright}\n'''
+packages_list = '''Packages Found:  {list}\n'''
+licenses_list = '''Licenses Found:  {list}\n'''
+
 # notes
 package_notes = '''Errors: {package_info_retrieval_errors}\n''' \
     '''Improvements: {package_info_reporting_improvements}\n'''

--- a/tern/report/report.py
+++ b/tern/report/report.py
@@ -17,7 +17,6 @@ import sys
 from stevedore import driver
 from stevedore.exception import NoMatches
 
-from tern.report import content
 from tern.report import errors
 from tern.report import formats
 from tern.report.analyze import analyze_docker_image
@@ -176,24 +175,7 @@ def generate_report(args, *images):
     '''Generate a report based on the command line options'''
     if args.report_format:
         return generate_format(images, args.report_format)
-    if args.summary:
-        return generate_verbose(True, images)
-    return generate_verbose(False, images)
-
-
-def generate_verbose(is_summary, images):
-    '''Generate a verbose report'''
-    report = formats.disclaimer.format(
-        version_info=content.get_tool_version())
-    if is_summary:
-        logger.debug('Creating a summary of components in image...')
-        for image in images:
-            report = report + content.print_summary_report(image)
-    else:
-        logger.debug('Creating a detailed report of components in image...')
-        for image in images:
-            report = report + content.print_full_report(image)
-    return report
+    return generate_format(images, 'default')
 
 
 def generate_format(images, format_string):


### PR DESCRIPTION
The current default verbose report is too long and contains too much
information for any person to sift through. This commit replaces the
verbose report with a more concise general summary of the container
image that includes the following information:
 - BaseOS if Tern can find it
 - Commands used to collect package information
 - List of packages + their versions
 - List of licenses found

This commit also separates the default report into its own plugin (aptly
named 'default'). If no plugin is chosen on the command line, the
default plugin report will be generated. In order to implement this in
the code, the `print_full_report()` function was modified and moved from
`tern/report/content.py` to `tern/formats/default/generator.py`.

Lastly, this commit removes the current summary report option from the
command line and any code that was associated with implementing it in
`tern/format/content.py` and `tern/format/report.py`.

Resolves #363

Signed-off-by: Rose Judge <rjudge@vmware.com>