### PR TITLE
ci: Replace unit test for DockerImage class

### DIFF
--- a/ci/test_files_touched.py
+++ b/ci/test_files_touched.py
@@ -47,7 +47,7 @@ test_suite = {
     re.compile('tern/classes/command.py'):
     ['python tests/test_class_command.py'],
     re.compile('tern/classes/docker_image.py'):
-    ['python tests/test_class_docker_image.py'],
+    ['tern -l report -i photon:3.0'],
     re.compile('tern/classes/image.py'):
     ['python tests/test_class_image.py'],
     re.compile('tern/classes/image_layer.py'):


### PR DESCRIPTION
There is currently no way of testing the DockerImage class because
it requires a real image produced by Docker. Docker images can be
overwritten or cleaned up by their repository maintainers, so this
is not a reliable way of testing the class. In the future, the
project may be able to create a test container which can be controlled
by the community and maintainers.

For now, replace running the unit test with a functional test.

Signed-off-by: Nisha K <nishak@vmware.com>