### PR TITLE
WIP: Precautions against external interference

### DIFF
--- a/tern/__main__.py
+++ b/tern/__main__.py
@@ -58,8 +58,17 @@ def get_version():
     return message
 
 
+def create_top_dir():
+    '''Create the top level working directory'''
+    top_dir = general.get_top_dir()
+    if not os.path.isdir(top_dir):
+        os.mkdir(top_dir)
+
+
 def do_main(args):
     '''Execute according to subcommands'''
+    # create working directory
+    create_top_dir()
     if args.log_stream:
         # set up console logs
         global logger

--- a/tern/analyze/common.py
+++ b/tern/analyze/common.py
@@ -20,6 +20,7 @@ from tern.report import content
 from tern.utils import cache
 from tern.utils import constants
 from tern.utils import general
+from tern.utils import rootfs
 
 # global logger
 logger = logging.getLogger(constants.logger_name)
@@ -73,7 +74,7 @@ def get_base_bin():
     binary = ''
     # the path to where the filesystem is mounted
     # look at utils/rootfs.py mount_base_layer module
-    cwd = os.path.join(os.getcwd(), constants.temp_folder, constants.mergedir)
+    cwd = os.path.join(rootfs.get_working_dir(), constants.mergedir)
     for key, value in command_lib.command_lib['base'].items():
         for path in value['path']:
             if os.path.exists(os.path.join(cwd, path)):
@@ -89,10 +90,10 @@ def get_os_release():
     # os-release may exist under /etc/ or /usr/lib. We should first check
     # for the preferred /etc/os-release and fall back on /usr/lib/os-release
     # if it does not exist under /etc
-    etc_path = os.path.join(os.getcwd(), constants.temp_folder,
-                            constants.mergedir, constants.etc_release_path)
-    lib_path = os.path.join(os.getcwd(), constants.temp_folder,
-                            constants.mergedir, constants.lib_release_path)
+    etc_path = os.path.join(rootfs.get_working_dir(), constants.mergedir,
+                            constants.etc_release_path)
+    lib_path = os.path.join(rootfs.get_working_dir(), constants.mergedir,
+                            constants.lib_release_path)
     if not os.path.exists(etc_path):
         if not os.path.exists(lib_path):
             return ''

--- a/tern/classes/docker_image.py
+++ b/tern/classes/docker_image.py
@@ -7,8 +7,8 @@ import json
 import os
 import subprocess  # nosec
 
+from tern.utils import rootfs
 from tern.utils.general import pushd
-from tern.utils.constants import temp_folder
 from tern.utils.constants import manifest_file
 from tern.analyze.docker.container import extract_image_metadata
 from tern.analyze.docker.dockerfile import tag_separator
@@ -72,7 +72,7 @@ class DockerImage(Image):
     def get_image_manifest(self):
         '''Assuming that there is a temp folder with a manifest.json of
         an image inside, get a dict of the manifest.json file'''
-        temp_path = os.path.abspath(temp_folder)
+        temp_path = rootfs.get_working_dir()
         with pushd(temp_path):
             with open(manifest_file) as f:
                 json_obj = json.loads(f.read())
@@ -110,7 +110,7 @@ class DockerImage(Image):
         config_file = self.get_image_config_file(manifest)
         # assuming that the config file path is in the same root path as the
         # manifest file
-        temp_path = os.path.abspath(temp_folder)
+        temp_path = rootfs.get_working_dir()
         with pushd(temp_path):
             with open(config_file) as f:
                 json_obj = json.loads(f.read())

--- a/tern/report/errors.py
+++ b/tern/report/errors.py
@@ -52,6 +52,7 @@ no_shell_listing = '''There is no listing for 'shell' under the base ''' \
     '''{default_shell}\n'''
 unknown_content = '''Unknown content included in layer {files}. Please ''' \
     '''analyze these files separately\n'''
+keyboard_interrupt = '''Keyboard Interrupt! Aborting analysis...'''
 
 # Dockerfile specific errors
 dockerfile_no_tag = '''The Dockerfile provided has no tag in the line ''' \

--- a/tern/report/report.py
+++ b/tern/report/report.py
@@ -79,7 +79,7 @@ def clean_image_tars(image_obj):
 def clean_working_dir(bind_mount):
     '''Clean up the working directory
     If bind_mount is true then leave the upper level directory'''
-    path = os.path.abspath(constants.temp_folder)
+    path = rootfs.get_working_dir()
     if os.path.exists(path):
         if bind_mount:
             # clean whatever is in temp_folder without removing the folder

--- a/tern/tools/container_debug.py
+++ b/tern/tools/container_debug.py
@@ -22,7 +22,7 @@ from tern.report import report
 def cleanup():
     """Clean up the working directory"""
     rootfs.clean_up()
-    report.clean_working_dir(False)
+    rootfs.root_command(rootfs.remove, rootfs.get_working_dir())
 
 
 def unmount():
@@ -40,15 +40,14 @@ def unmount():
 
 def get_mount_path():
     """Get the path where the filesystem is mounted"""
-    return os.path.join(os.getcwd(), constants.temp_folder, constants.mergedir)
+    return os.path.join(rootfs.get_working_dir(), constants.mergedir)
 
 
 def check_shell():
     """Check if any shell binary is available in the mounted filesystem"""
     shells = ['/bin/sh', '/bin/bash', '/usr/bin/bash']
-    cwd = get_mount_path()
     for shell in shells:
-        if os.path.exists(os.path.join(cwd, shell[1:])):
+        if os.path.exists(os.path.join(get_mount_path(), shell[1:])):
             return shell
     return ''
 

--- a/tern/utils/cache.py
+++ b/tern/utils/cache.py
@@ -19,6 +19,7 @@ It is organized in this way:
 import os
 import yaml
 from tern.utils.constants import cache_file
+from tern.utils.general import get_top_dir
 
 # known base image database
 cache = {}
@@ -29,10 +30,10 @@ def load():
     global cache
 
     # Do not try to populate the cache if there is no cache available
-    if not os.path.exists(os.path.abspath(cache_file)):
+    if not os.path.exists(os.path.join(get_top_dir(), cache_file)):
         return
 
-    with open(os.path.abspath(cache_file)) as f:
+    with open(os.path.join(get_top_dir(), cache_file)) as f:
         cache = yaml.safe_load(f)
 
 
@@ -61,7 +62,7 @@ def add_layer(layer_obj):
 
 def save():
     '''Save the cache to the cache file'''
-    with open(os.path.abspath(cache_file), 'w') as f:
+    with open(os.path.join(get_top_dir(), cache_file), 'w') as f:
         yaml.dump(cache, f, default_flow_style=False)
 
 
@@ -78,5 +79,5 @@ def clear():
     '''Empty the cache - don't use unless you really have to'''
     global cache
     cache = {}
-    with open(os.path.abspath(cache_file), 'w') as f:
+    with open(os.path.join(get_top_dir(), cache_file), 'w') as f:
         yaml.dump(cache, f, default_flow_style=False)

--- a/tern/utils/constants.py
+++ b/tern/utils/constants.py
@@ -7,8 +7,12 @@
 Constants
 '''
 
-# temporary folder for extracting container image
-# this is relative to where the tern executable is
+# paths for working on container images
+# this is relative to the user's home directory
+
+# hidden folder
+dot_folder = '.tern'
+# working folder
 temp_folder = 'temp'
 # temporary tar file
 temp_tarfile = 'temp.tar'

--- a/tern/utils/general.py
+++ b/tern/utils/general.py
@@ -8,8 +8,9 @@ import random
 import re
 import subprocess  # nosec
 from contextlib import contextmanager
-
+from pathlib import Path
 from pbr.version import VersionInfo
+
 from tern.utils import constants
 
 
@@ -25,6 +26,11 @@ def pushd(path):
     os.chdir(path)
     yield
     os.chdir(curr_path)
+
+
+def get_top_dir():
+    '''Get the hidden working directory'''
+    return os.path.join(str(Path.home()), constants.dot_folder)
 
 
 def initialize_names():

--- a/tern/utils/rootfs.py
+++ b/tern/utils/rootfs.py
@@ -222,6 +222,21 @@ def clean_up():
     root_command(remove, workdir_path)
 
 
+def recover():
+    '''Recover after some external error'''
+    # try to unmount proc, sys and dev first
+    try:
+        undo_mount()
+    except subprocess.CalledProcessError:
+        pass
+    try:
+        unmount_rootfs()
+    except subprocess.CalledProcessError:
+        pass
+    # clean up the working directory
+    clean_up()
+
+
 def calc_fs_hash(fs_path):
     '''Given the path to the filesystem, calculate the filesystem hash
     We run a shell script located in the tools directory to get the


### PR DESCRIPTION
Sometimes, a user may issue a keyboard interrupt during container
image analysis if it takes too long. In this situation, the working
folder will remain with all mount points still mounted. This
includes /sys, /dev, and /proc which are bind mounted to the host
machine. If the user tries to remove this folder using elevated
privileges, some of the devices and processor information will get
deleted as well and the host machine will be corrupted for that
session. Although this state is recoverable on reboot, it isn't
an ideal situation for a user to be in.

We deal with this problem by checking for the KeyboardInterrupt
exception during analysis. There are two places for this - analysis
using the system level tools and analysis using snippets.

- Added a function in rootfs.py to recover the mounted filesystems
- Added a "Keyboard Interrupt" error to the list of errors
- Added a function in analyze.py to use the recover function and
  exit gracefully

Signed-off-by: Nisha K <nishak@vmware.com>