### PR TITLE
Enable cli to use raw container image

### DIFF
--- a/tern/analyze/common.py
+++ b/tern/analyze/common.py
@@ -9,6 +9,7 @@ Common functions
 
 import logging
 import os
+import tarfile
 
 from tern.classes.package import Package
 from tern.classes.notice import Notice
@@ -446,3 +447,11 @@ def get_os_style(image_layer, binary):
                     package_manager=binary,
                     package_format=image_layer.pkg_format,
                     os_list=image_layer.os_guess), 'info'))
+
+
+def check_tar(tar_file):
+    '''Check if provided file is a valid tar archive file'''
+    if os.path.exists(tar_file):
+        if tarfile.is_tarfile(tar_file):
+            return True
+    return False

--- a/tern/analyze/docker/run.py
+++ b/tern/analyze/docker/run.py
@@ -71,16 +71,21 @@ def get_dockerfile_packages():
 
 def execute_docker_image(args):
     '''Execution path if given a Docker image'''
-    check_docker_daemon()
     logger.debug('Setting up...')
-    report.setup(image_tag_string=args.docker_image)
+    image_string = args.docker_image
+    if not args.raw_image:
+        # don't check docker daemon for raw images
+        check_docker_daemon()
+    else:
+        image_string = args.raw_image
+    report.setup(image_tag_string=image_string)
     # attempt to get built image metadata
-    full_image = report.load_full_image(args.docker_image)
+    full_image = report.load_full_image(image_string)
     if full_image.origins.is_empty():
         # image loading was successful
         # Add an image origin here
         full_image.origins.add_notice_origin(
-            formats.docker_image.format(imagetag=args.docker_image))
+            formats.docker_image.format(imagetag=image_string))
         # analyze image
         analyze_docker_image(full_image, args.redo)
         # generate report

--- a/tern/report/errors.py
+++ b/tern/report/errors.py
@@ -53,6 +53,10 @@ no_shell_listing = '''There is no listing for 'shell' under the base ''' \
 unknown_content = '''Unknown content included in layer {files}. Please ''' \
     '''analyze these files separately\n'''
 keyboard_interrupt = '''Keyboard Interrupt! Aborting analysis...'''
+invalid_raw_image = '''Invalid raw image provided: '{image}' - Check ''' \
+    '''that path to raw image is correct and in tar archive format.'''
+incorrect_raw_option = '''Expected docker image but detected file in ''' \
+    '''tar archive format.'''
 
 # Dockerfile specific errors
 dockerfile_no_tag = '''The Dockerfile provided has no tag in the line ''' \

--- a/tern/report/report.py
+++ b/tern/report/report.py
@@ -19,6 +19,7 @@ from stevedore.exception import NoMatches
 from tern.report import errors
 from tern.report import formats
 from tern.analyze.docker import container
+from tern.analyze import common
 from tern.utils import constants
 from tern.utils import cache
 from tern.utils import general
@@ -51,7 +52,7 @@ def setup(dockerfile=None, image_tag_string=None):
     if dockerfile:
         dhelper.load_docker_commands(dockerfile)
     # check if the docker image is present
-    if image_tag_string:
+    if image_tag_string and common.check_tar(image_tag_string) is False:
         if not container.check_image(image_tag_string):
             # if no docker image is present, try to pull it
             if not container.pull_image(image_tag_string):


### PR DESCRIPTION
This commit adds functionality so that Tern can accept a local raw
image tarball as an alternative to the current image:tag string option.
This functionality is implemented using an additional command line
option 'report -w' or 'report --raw-image'. If the user invokes Tern
with the --raw-image command line option and the input is corrupted or
does not exist at the specified location, Tern will abruptly and
gracefully exit.

Resolves #64

Signed-off-by: Rose Judge <rjudge@vmware.com>