### PR TITLE
Fix info overwriting  when retrieving from cache

### DIFF
--- a/tern/classes/origins.py
+++ b/tern/classes/origins.py
@@ -46,7 +46,8 @@ class Origins:
             self.__origins.append(notice_orij)
 
     def add_notice_origin(self, orig_string):
-        self.__origins.append(NoticeOrigin(orig_string))
+        if not self.get_origin(orig_string):
+            self.__origins.append(NoticeOrigin(orig_string))
 
     def is_empty(self):
         empty = True

--- a/tern/report/formats.py
+++ b/tern/report/formats.py
@@ -33,8 +33,9 @@ retrieve_from_cache = '''Retrieving packages from cache for layer ''' \
 # command library
 base_listing = '''Direct listing in command_lib/base.yml'''
 snippet_listing = '''Direct listing in command_lib/snippets.yml'''
-invoke_for_base = '''Using invoke listing in command_lib/base.yml'''
-invoke_for_snippets = '''Using invoke listing in command_lib/snippets.yml'''
+invoke_for_base = '''Retrieved by invoking listing in command_lib/base.yml'''
+invoke_for_snippets = '''Retrieved by invoking listing in command_lib/''' \
+    '''snippets.yml'''
 invoke_in_container = '''\tin container:\n'''
 invoke_on_host = '''\ton host:\n'''
 # package information

--- a/tern/utils/cache.py
+++ b/tern/utils/cache.py
@@ -50,6 +50,13 @@ def get_layers():
     return cache.keys()
 
 
+def get_origins(layer_hash):
+    '''Return the origins dictionary'''
+    if 'origins' in cache[layer_hash].keys():
+        return cache[layer_hash]['origins']
+    return []
+
+
 def add_layer(layer_obj):
     '''Given a layer object, add it to the cache
     We use the layer's to_dict object and make a dictionary such that


### PR DESCRIPTION
When checking to see if information about an image layer is already
cached, the tool will record that information in a notice. When the
cache gets saved at the end of a run, all the notices recorded when
the layer was first processed gets overwritten by the new notice
which just informs you that it got the information about the layer
from the cache. This change fixes this bug.

- Remove the recording of the notice that the tool has pulled
information from the cache. It's enough if the tool just logs that
event.
- Along with loading the package information from the cache into
the layer object, also load the notices. Added a new function to
load the notices from the cache.
- For the Origin's class method add_notice_origin, check first if
the origin string already exists in the list of notice origin
objects before adding it. This prevents multiple instances of the
class with the same origin string.
- Made some changes to the message format to make it more
understandable about what method the tool used to get the
information
- Added a function to cache.py to retrieve the 'origins' part of
the cache which will be used in the load_notices_from_cache
function in common.py

Resolves #466

Signed-off-by: Nisha K <nishak@vmware.com>