### PR TITLE
Catch exceptions when docker is not set up

### DIFF
--- a/tern/analyze/docker/run.py
+++ b/tern/analyze/docker/run.py
@@ -8,8 +8,6 @@ Execute a Docker container image
 """
 
 import logging
-import sys
-import docker
 
 from tern.report import formats
 from tern.report import report
@@ -27,16 +25,6 @@ from tern.analyze.passthrough import run_extension
 
 # global logger
 logger = logging.getLogger(constants.logger_name)
-
-
-def check_docker_daemon():
-    '''Check if the Docker daemon is running. If not, exit gracefully'''
-    try:
-        docker.from_env()
-    except IOError as error:
-        logger.error('Docker daemon is not running: %s',
-                     error.output.decode('utf-8'))
-        sys.exit()
 
 
 def get_dockerfile_packages():
@@ -85,7 +73,7 @@ def execute_docker_image(args):
     image_string = args.docker_image
     if not args.raw_image:
         # don't check docker daemon for raw images
-        check_docker_daemon()
+        container.check_docker_setup()
     else:
         image_string = args.raw_image
     report.setup(image_tag_string=image_string)
@@ -113,7 +101,7 @@ def execute_docker_image(args):
 
 def execute_dockerfile(args):
     '''Execution path if given a dockerfile'''
-    check_docker_daemon()
+    container.check_docker_setup()
     logger.debug('Setting up...')
     report.setup(dockerfile=args.dockerfile)
     # attempt to build the image


### PR DESCRIPTION
The way we checked to see if the docker daemon was set up
correctly using the python API was to user docker.from_env() but
this only returns a client object. It doesn't actually check to
see if the client can send requests to the docker daemon. As a
result, when Docker is not installed or the daemon is not running
or the user has insufficient permissions (in this case, the user
id needs to be in the docker group), then the tool fails and the
user sees a rather long traceback because the python API assumes
that docker is installed and set up correctly. We fix this by
adding client.ping() to our check to see if everything is set up
in a try-catch loop. We also do a bit of refactoring so code is
not duplicated.

- Create a new function in container.py which will check if the
client calls work.
- Based on what the returned error is, we log whether the issue
is due to Docker not being installed or the docker daemon not
running, or whether the user has insufficient permissions.
- Use this new function in run.py when executing docker specific
subroutines.
- To satisfy linting for redefining the ConnectionError builtin
which is also a requests exception, we just import requests and
use the exceptions wherever needed.

Fixes #207

Signed-off-by: Nisha K <nishak@vmware.com>