### PR TITLE
docs: Fix lab tutorial formatting typo

### DIFF
--- a/docs/tern-lab-tutorial.md
+++ b/docs/tern-lab-tutorial.md
@@ -127,8 +127,8 @@ Please read our [code of conduct](https://github.com/vmware/tern/blob/master/COD
 
 ## Authors
 
-* ** Nisha Kumar** - nishak@vmware.com
-* ** Rose Judge** - rjudge@vmware.com
+* **Nisha Kumar** - nishak@vmware.com
+* **Rose Judge** - rjudge@vmware.com
 
 ## License
 


### PR DESCRIPTION
There was an extra space after the '**' in the author section of the
docs/tern-lab-tutorial.md file. The intention of the '**' was to bold
the authors' names but was not rendering bold in markdown because of
the space. This small commit fixes that formatting error.

Signed-off-by: Rose Judge <rjudge@vmware.com>