### PR TITLE
extensions: Added initial scancode extension

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,7 @@ tern.formats =
     yaml = tern.formats.yaml.generator:YAML
 tern.extensions =
     cve_bin_tool = tern.extensions.cve_bin_tool.executor:CveBinTool
+    scancode = tern.extensions.scancode.executor:Scancode
 console_scripts = 
     tern = tern.__main__:main
 

--- a/tern/extensions/scancode/__init__.py
+++ b/tern/extensions/scancode/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause

--- a/tern/extensions/scancode/executor.py
+++ b/tern/extensions/scancode/executor.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""
+Execute scancode
+https://github.com/nexB/scancode-toolkit
+This plugin does not support installation of scancode
+The expected environment is as follows:
+    1. Create a python3 virtual environment
+    2. Clone the scancode repo here and cd into it
+    3. pip install tern in this virtual environment
+    4. run tern report -x scancode
+"""
+
+import json
+import logging
+import sys
+
+from tern.analyze import passthrough
+from tern.extensions.executor import Executor
+from tern.utils import constants
+
+
+logger = logging.getLogger(constants.logger_name)
+
+
+class Scancode(Executor):
+    '''Execute scancode'''
+    def execute(self, image_obj):
+        '''Execution should be:
+            ./scancode -lpcu --quiet --json - /path/to/directory
+        scancode-toolkit will be released as a pip package supporting python3
+        soon.
+        '''
+        command = './scancode -lpcu --quiet --json -'
+        # run the command against the image filesystems
+        if not passthrough.run_on_image(image_obj, command):
+            logger.error("scancode error")
+            sys.exit(1)
+        # for now we just print the file path and licenses found if there are
+        # any licenses are found
+        for layer in image_obj.layers:
+            print('Layer: {}'.format(layer.diff_id[:10]))
+            results = json.loads(layer.analyzed_output)
+            for afile in results['files']:
+                if afile['licenses']:
+                    license_str = ','.join(l['key'] for l in afile['licenses'])
+                    print('{}: {}'.format(afile['path'], license_str))


### PR DESCRIPTION
scancode-toolkit is a python project that does file level scanning
for licenses. This change introduces an extension for this tool.
At the time of this change, scancode's pip package was not installing
due to a missing dependency. While the project figures out a fix, we
will assume that we are working from the root of the git repo within
a python3 virtual environment. Once the fix is in, we will assume
that we are using the python3 pip package.

The executor just runs the appropriate cli command to get licenses,
packages, copyright info and project urls in a pure json object that
gets stored in each ImageLayer object's analyzed_output property.
We then parse the json object and print out the file paths that have
a list of licenses associated with them. This implementation
puts in place the extension without filling in the required metadata
so reporting and multiple formats are not supported here.

Resolves #474

Signed-off-by: Nisha K <nishak@vmware.com>