### PR TITLE
Dockerfile: add tar dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM photon:3.0
 # install system dependencies
 # photon:3.0 comes with toybox which conflicts with some dependencies needed for tern to work, so uninstalling
 # toybox first
-RUN tdnf remove -y toybox && tdnf install -y findutils attr util-linux python3 python3-pip python3-setuptools git
+RUN tdnf remove -y toybox && tdnf install -y tar findutils attr util-linux python3 python3-pip python3-setuptools git
 
 # install pip and tern
 RUN pip3 install --upgrade pip && pip3 install tern


### PR DESCRIPTION
Tern requires tar to extract the image, this commit adds the
tar package using tdnf to the ternd image.

Log without tar:

DEBUG - run - Setting up...
DEBUG - container - Checking if image "debian:buster" is available on disk...
DEBUG - container - Image "debian:buster" found
DEBUG - rootfs - Running command: tar -tf /root/.tern/temp.tar
WARNING - report - Error in loading image: [Errno 2] No such file or directory:\
          'tar': 'tar'
WARNING - run - Cannot retrieve full image metadata

Log with tar:
DEBUG - __main__ - Starting...
DEBUG - run - Setting up...
DEBUG - container - Checking if image
"debian:buster" is available on disk...
DEBUG - container - Image "debian:buster"
found
DEBUG - rootfs - Running command: tar -tf /root/.tern/temp.tar

Signed-off-by: Jesus Ornelas Aguayo <jesus.ornelas.aguayo@intel.com>