### PR TITLE
Update Dockerfile to include Tar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM photon:3.0
 # install system dependencies
 # photon:3.0 comes with toybox which conflicts with some dependencies needed for tern to work, so uninstalling
 # toybox first
-RUN tdnf remove -y toybox && tdnf install -y findutils attr util-linux python3 python3-pip python3-setuptools git
+RUN tdnf remove -y toybox && tdnf install -y findutils attr util-linux python3 python3-pip python3-setuptools git tar
 
 # install pip and tern
 RUN pip3 install --upgrade pip && pip3 install tern


### PR DESCRIPTION
In our testing of the tern repo, we saw failures wherever tar was used. Added it to the list of installed packages and the errors went away.