### PR TITLE
Fix overlayfs mount location when running Tern in a container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN tdnf remove -y toybox && tdnf install -y tar findutils attr util-linux pytho
 RUN pip3 install --upgrade pip && pip3 install tern
 
 # make a mounting directory
-RUN mkdir temp
+RUN mkdir hostmount
 
-ENTRYPOINT ["tern", "-b"]
+ENTRYPOINT ["tern", "-b", "/hostmount"]
 CMD ["-h"]

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+FROM photon:3.0
+
+# install system dependencies
+# photon:3.0 comes with toybox which conflicts with some dependencies needed for tern to work, so uninstalling
+# toybox first
+RUN tdnf remove -y toybox && tdnf install -y tar findutils attr util-linux python3 python3-pip python3-setuptools git
+
+# install pip
+RUN pip3 install --upgrade pip
+
+# install tern with latest changes
+COPY dist/tern-*.tar.gz .
+RUN pip install tern-*.tar.gz
+
+# make a mounting directory
+RUN mkdir hostmount
+
+ENTRYPOINT ["tern", "-b", "/hostmount"]
+CMD ["-h"]

--- a/ci/test_files_touched.py
+++ b/ci/test_files_touched.py
@@ -38,7 +38,8 @@ test_suite = {
     re.compile('requirements.txt'): ['tern -l report -i photon:3.0'],
     # Dockerfile
     re.compile('Dockerfile'): [
-        'docker build -t ternd .',
+        'python3 setup.py sdist && '
+        'docker build -t ternd -f ci/Dockerfile . && '
         './docker_run.sh workdir ternd "report -i golang:alpine"'],
     # Files under tern directory
     re.compile('tern/__init__.py|tern/__main__.py'):

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -12,4 +12,4 @@
 # Example: ./docker_run.sh workdir ternd "report -i golang:alpine"
 
 mkdir -p $1
-docker run --privileged -v /var/run/docker.sock:/var/run/docker.sock --mount type=bind,source=$PWD/$1,target=/temp $2 $3
+docker run --privileged -v /var/run/docker.sock:/var/run/docker.sock --mount type=bind,source=$PWD/$1,target=/hostmount $2 $3

--- a/tern/__main__.py
+++ b/tern/__main__.py
@@ -19,6 +19,7 @@ from tern.analyze.docker import run
 from tern.utils import cache
 from tern.utils import constants
 from tern.utils import general
+from tern.utils import rootfs
 from tern.report import errors
 
 
@@ -69,6 +70,8 @@ def create_top_dir():
 
 def do_main(args):
     '''Execute according to subcommands'''
+    # set bind mount location if working in a container
+    rootfs.set_mount_dir(args.bind_mount)
     # create working directory
     create_top_dir()
     if args.log_stream:
@@ -115,9 +118,9 @@ def main():
     parser.add_argument('-k', '--keep-wd', action='store_true',
                         help="Keep the working directory after execution."
                         " Useful when debugging container images")
-    parser.add_argument('-b', '--bind-mount', action='store_true',
-                        help="Treat working directory as a bind mount."
-                        " Needed when running from within a container")
+    parser.add_argument('-b', '--bind-mount', metavar='BIND_DIR',
+                        help="Absolute path to bind mount target. Needed"
+                        " when running from within a container.")
     parser.add_argument('-r', '--redo', action='store_true',
                         help="Repopulate the cache for found layers")
     # sys.version gives more information than we care to print

--- a/tern/analyze/docker/run.py
+++ b/tern/analyze/docker/run.py
@@ -96,7 +96,7 @@ def execute_docker_image(args):
     logger.debug('Teardown...')
     report.teardown()
     if not args.keep_wd:
-        report.clean_working_dir(args.bind_mount)
+        report.clean_working_dir()
 
 
 def execute_dockerfile(args):
@@ -161,4 +161,4 @@ def execute_dockerfile(args):
     logger.debug('Teardown...')
     report.teardown()
     if not args.keep_wd:
-        report.clean_working_dir(args.bind_mount)
+        report.clean_working_dir()

--- a/tern/report/report.py
+++ b/tern/report/report.py
@@ -82,17 +82,7 @@ def clean_working_dir(bind_mount):
     If bind_mount is true then leave the upper level directory'''
     path = rootfs.get_working_dir()
     if os.path.exists(path):
-        if bind_mount:
-            # clean whatever is in temp_folder without removing the folder
-            inodes = os.listdir(path)
-            for inode in inodes:
-                dir_path = os.path.join(path, inode)
-                if os.path.isdir(dir_path):
-                    shutil.rmtree(dir_path)
-                else:
-                    os.remove(dir_path)
-        else:
-            shutil.rmtree(path)
+        shutil.rmtree(path)
 
 
 def load_base_image():

--- a/tern/report/report.py
+++ b/tern/report/report.py
@@ -77,7 +77,7 @@ def clean_image_tars(image_obj):
             rootfs.root_command(rootfs.remove, fspath)
 
 
-def clean_working_dir(bind_mount):
+def clean_working_dir():
     '''Clean up the working directory
     If bind_mount is true then leave the upper level directory'''
     path = rootfs.get_working_dir()

--- a/tern/utils/cache.py
+++ b/tern/utils/cache.py
@@ -21,7 +21,6 @@ import yaml
 from tern.utils.constants import cache_file
 from tern.utils import rootfs
 
-
 # known base image database
 cache = {}
 

--- a/tern/utils/cache.py
+++ b/tern/utils/cache.py
@@ -19,7 +19,8 @@ It is organized in this way:
 import os
 import yaml
 from tern.utils.constants import cache_file
-from tern.utils.general import get_top_dir
+from tern.utils import rootfs
+
 
 # known base image database
 cache = {}
@@ -30,10 +31,10 @@ def load():
     global cache
 
     # Do not try to populate the cache if there is no cache available
-    if not os.path.exists(os.path.join(get_top_dir(), cache_file)):
+    if not os.path.exists(os.path.join(rootfs.mount_dir, cache_file)):
         return
 
-    with open(os.path.join(get_top_dir(), cache_file)) as f:
+    with open(os.path.join(rootfs.mount_dir, cache_file)) as f:
         cache = yaml.safe_load(f)
 
 
@@ -69,7 +70,7 @@ def add_layer(layer_obj):
 
 def save():
     '''Save the cache to the cache file'''
-    with open(os.path.join(get_top_dir(), cache_file), 'w') as f:
+    with open(os.path.join(rootfs.mount_dir, cache_file), 'w') as f:
         yaml.dump(cache, f, default_flow_style=False)
 
 
@@ -86,5 +87,5 @@ def clear():
     '''Empty the cache - don't use unless you really have to'''
     global cache
     cache = {}
-    with open(os.path.join(get_top_dir(), cache_file), 'w') as f:
+    with open(os.path.join(rootfs.mount_dir, cache_file), 'w') as f:
         yaml.dump(cache, f, default_flow_style=False)

--- a/tern/utils/rootfs.py
+++ b/tern/utils/rootfs.py
@@ -32,7 +32,6 @@ unmount = ['umount']
 
 mount_dir = None
 
-
 # enable host DNS settings
 host_dns = ['cp', constants.resolv_path]
 

--- a/tern/utils/rootfs.py
+++ b/tern/utils/rootfs.py
@@ -30,6 +30,9 @@ mount_sys = ['mount', '-o', 'bind', '/sys']
 mount_dev = ['mount', '-o', 'bind', '/dev']
 unmount = ['umount']
 
+mount_dir = None
+
+
 # enable host DNS settings
 host_dns = ['cp', constants.resolv_path]
 
@@ -41,6 +44,17 @@ union_mount = ['mount', '-t', 'overlay', 'overlay', '-o']
 
 # global logger
 logger = logging.getLogger(constants.logger_name)
+
+
+def set_mount_dir(bind=None):
+    '''Set mount directory according to --bind-mount CLI option (or lack
+    thereof). The mount_dir value is used to set the working directory
+    properly in get_working_dir().'''
+    global mount_dir
+    if bind:
+        mount_dir = bind
+    else:
+        mount_dir = general.get_top_dir()
 
 
 def root_command(command, *extra):
@@ -105,7 +119,7 @@ def check_tar_members(tar_file):
 def get_working_dir():
     '''General purpose utility to return the absolute path of the working
     directory'''
-    return os.path.join(general.get_top_dir(), constants.temp_folder)
+    return os.path.join(mount_dir, constants.temp_folder)
 
 
 def get_untar_dir(layer_tarfile):


### PR DESCRIPTION
The overlay mount inside of the docker container was failing as it
was trying to mount on top of another overlay mount point.

This series of commits fixes the working directory when running
in a container to be the bind mount target instead of an absolute path,
$HOME/.tern/temp.

Fixes #498

Signed-off-by: Rose Judge <rjudge@vmware.com>