### PR TITLE
docs: Update README project status

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,15 +232,14 @@ $ python tests/<test file>.py
 ```
 
 ## Project Status<a name="project-status"/>
-Release 0.5.4 is here!
+Release 1.0.0 was released at the beginning of November. A follow-up release, v1.0.1, was made available at the beginning of December to address a regression found when running Tern in a Docker container.
 
-See the [release notes](docs/releases/v0_5_0.md) for more information. See the [update notes](docs/releases/v0_5_4.md) for patches on top of this release.
+See the [release notes](docs/releases/v1_0_0.md) for more information. See the [update notes](docs/releases/v1_0_1.md) for patches on top of this release.
 
-We try to keep the [project roadmap](./docs/project-roadmap.md) as up to date as possible. We are currently working on Release 1.0.0.
-
-Somewhere along the line of development, we accidentally rewrote git history on the master branch. Some merge commits are gone but the commits that have all the changes and the tags are still there. We're truly sorry about this mistake and we are working on ways in which we, the ones with admin privileges on the project, will not shoot ourselves in the foot again.
+We try to keep the [project roadmap](./docs/project-roadmap.md) as up to date as possible. We are currently working on Release 1.1.0.
 
 ## Releases
+* [v1.0.1](docs/releases/v1_0_1.md)
 * [v0.5.4](docs/releases/v0_5_4.md)
 * [v0.4.0](docs/releases/v0_4_0.md)
 * [v0.3.0](docs/releases/v0_3_0.md)


### PR DESCRIPTION
This commit updates the README file for Tern to reflect the current
project status after the latest release (v1.0.1).

Signed-off-by: Rose Judge <rjudge@vmware.com>