### PR TITLE
executor: scancode: Use pip package

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,19 @@ $ tern -l report -f spdxtagvalue -i golang:1.12-alpine -o spdx.txt
 Tern does not have its own file level license scanner. In order to fill in the gap, Tern allows you to extend container image analysis with an external file analysis CLI tool or Python3 module.
 
 ## Scancode<a name="scancode">
-[scancode-toolkit](https://github.com/nexB/scancode-toolkit) is a license analysis tool that "detects licenses, copyrights, package manifests and direct dependencies and more both in source code and binary files". To use it to analyze container images, run:
+[scancode-toolkit](https://github.com/nexB/scancode-toolkit) is a license analysis tool that "detects licenses, copyrights, package manifests and direct dependencies and more both in source code and binary files".
+
+1. Setup a python virtual environment
+```
+$ python3 -m venv scanenv
+$ cd scanenv
+$ source bin/activate
+```
+2. Install tern and scancode
+```
+$ pip install tern scancode
+```
+3. Run tern
 ```
 $ tern -l report -x scancode -i golang:1.12-alpine
 ```

--- a/tern/extensions/scancode/executor.py
+++ b/tern/extensions/scancode/executor.py
@@ -30,11 +30,9 @@ class Scancode(Executor):
     '''Execute scancode'''
     def execute(self, image_obj):
         '''Execution should be:
-            ./scancode -lpcu --quiet --json - /path/to/directory
-        scancode-toolkit will be released as a pip package supporting python3
-        soon.
+            scancode -lpcu --quiet --json - /path/to/directory
         '''
-        command = './scancode -lpcu --quiet --json -'
+        command = 'scancode -lpcu --quiet --json -'
         # run the command against the image filesystems
         if not passthrough.run_on_image(image_obj, command):
             logger.error("scancode error")


### PR DESCRIPTION
Scancode now has a working pip package. Update the executor to
use it instead of running it from the cloned git repository.

- Updated the executor's documentation.
- Called the general scancode package which should be installed
either on the system or in a virtual environment.
- Updated the README with instructions on how to run tern with
scancode

Signed-off-by: Nisha K <nishak@vmware.com>