### PR TITLE
Run extensions with sudo

### DIFF
--- a/tern/analyze/passthrough.py
+++ b/tern/analyze/passthrough.py
@@ -33,12 +33,12 @@ def get_filesystem_command(layer_obj, command):
     return cmd_list
 
 
-def execute_external_command(layer_obj, command):
+def execute_external_command(layer_obj, command, is_sudo=False):
     '''Given an Imagelayer object and a command in the form of a list, execute
     the command and store the results in the ImageLayer object either as
     results or as a Notice object'''
     origin_layer = 'Layer: ' + layer_obj.fs_hash[:10]
-    result, error = rootfs.shell_command(command)
+    result, error = rootfs.shell_command(is_sudo, command)
     if error:
         logger.error("Error in executing external command: %s", str(error))
         layer_obj.origins.add_notice_to_origins(origin_layer, Notice(
@@ -48,7 +48,7 @@ def execute_external_command(layer_obj, command):
     return True
 
 
-def run_on_image(image_obj, command):
+def run_on_image(image_obj, command, is_sudo=False):
     '''Given an Image object, for each layer, run the given command on the
     layer filesystem.
     The layer tarballs should already be extracted (taken care of when
@@ -65,7 +65,7 @@ def run_on_image(image_obj, command):
         layer.files_analyzed = True
         # get the actual command
         full_cmd = get_filesystem_command(layer, command)
-        if not execute_external_command(layer, full_cmd):
+        if not execute_external_command(layer, full_cmd, is_sudo):
             logger.error(
                 "Error in executing given external command: %s", command)
             return False

--- a/tern/analyze/passthrough.py
+++ b/tern/analyze/passthrough.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2019-2020 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
 """

--- a/tern/analyze/passthrough.py
+++ b/tern/analyze/passthrough.py
@@ -9,6 +9,7 @@ Use an external tool to analyze a container image
 
 
 import logging
+import shutil
 from stevedore import driver
 from stevedore.exception import NoMatches
 
@@ -26,6 +27,12 @@ def get_filesystem_command(layer_obj, command):
     This assumes that the layer tarball is untarred, which should have happened
     during the loading of the Image object'''
     cmd_list = command.split(' ')
+    # we first find if the command exists on the system
+    run_bin = cmd_list.pop(0)
+    bin_path = shutil.which(run_bin)
+    if not bin_path:
+        raise OSError("Command {} not found".format(run_bin))
+    cmd_list.insert(0, bin_path)
     # in most cases, the external tool has a CLI where the target directory
     # is the last token in the command. So the most straightforward way
     # to perform this operation is to append the target directory

--- a/tern/extensions/cve_bin_tool/executor.py
+++ b/tern/extensions/cve_bin_tool/executor.py
@@ -29,7 +29,7 @@ class CveBinTool(Executor):
         '''
         command = 'cve-bin-tool -u now'
         # run the command against the image filesystems
-        if not passthrough.run_on_image(image_obj, command):
+        if not passthrough.run_on_image(image_obj, command, True):
             logger.error("cve-bin-tool error")
             sys.exit(1)
         # for now we just print the results for each layer

--- a/tern/extensions/cve_bin_tool/executor.py
+++ b/tern/extensions/cve_bin_tool/executor.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2019-2020 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
 """

--- a/tern/extensions/scancode/executor.py
+++ b/tern/extensions/scancode/executor.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2019-2020 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
 """

--- a/tern/extensions/scancode/executor.py
+++ b/tern/extensions/scancode/executor.py
@@ -34,7 +34,7 @@ class Scancode(Executor):
         '''
         command = 'scancode -lpcu --quiet --json -'
         # run the command against the image filesystems
-        if not passthrough.run_on_image(image_obj, command):
+        if not passthrough.run_on_image(image_obj, command, True):
             logger.error("scancode error")
             sys.exit(1)
         # for now we just print the file path and licenses found if there are

--- a/tern/utils/general.py
+++ b/tern/utils/general.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2017-2020 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
 import os

--- a/tern/utils/general.py
+++ b/tern/utils/general.py
@@ -132,3 +132,11 @@ def check_tar(tar_file):
         if tarfile.is_tarfile(tar_file):
             return True
     return False
+
+
+def check_root():
+    '''Check to see if the current user is root or not. Return True if root
+    and False if not'''
+    if os.getuid() == 0:
+        return True
+    return False

--- a/tern/utils/rootfs.py
+++ b/tern/utils/rootfs.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2017-2020 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
 """

--- a/tern/utils/rootfs.py
+++ b/tern/utils/rootfs.py
@@ -99,7 +99,8 @@ def shell_command(is_sudo, command, *extra):
 def check_tar_permissions(tar_file, directory_path):
     '''Invoke a shell command as the current user. If the error contains
     'Operation not permitted' then return False. Else return True'''
-    _, error = shell_command(extract_tar, tar_file, '-C', directory_path)
+    _, error = shell_command(
+        False, extract_tar, tar_file, '-C', directory_path)
     if "Operation not permitted" in error.decode():
         return False
     return True
@@ -108,7 +109,7 @@ def check_tar_permissions(tar_file, directory_path):
 def check_tar_members(tar_file):
     '''Given the path to the tar file, check to see if there is an error with
     the members of the tarfile or if it is empty'''
-    result, error = shell_command(check_tar, tar_file)
+    result, error = shell_command(False, check_tar, tar_file)
     if error:
         logger.error("Malformed tar: %s", error.decode())
         raise EOFError("Malformed tarball: {}".format(tar_file))

--- a/tern/utils/rootfs.py
+++ b/tern/utils/rootfs.py
@@ -78,11 +78,15 @@ def root_command(command, *extra):
     return result
 
 
-def shell_command(command, *extra):
-    '''Invoke a shell command as a regular user.
+def shell_command(is_sudo, command, *extra):
+    '''Invoke a shell command as a regular user unless explicitly stated.
     This is used to check the result and error message of the command'''
     full_cmd = []
-    full_cmd.extend(command)  # we do this because command may be used again
+    if not isinstance(is_sudo, bool):
+        raise TypeError("First argument should be of type bool")
+    if not general.check_root() and is_sudo:
+        full_cmd.append('sudo')
+    full_cmd.extend(command)
     for arg in extra:
         full_cmd.append(arg)
     # invoke

--- a/tern/utils/rootfs.py
+++ b/tern/utils/rootfs.py
@@ -60,10 +60,8 @@ def root_command(command, *extra):
     '''Invoke a shell command as root or using sudo. The command is a
     list of shell command words'''
     full_cmd = []
-    sudo = True
-    if os.getuid() == 0:
-        sudo = False
-    if sudo:
+    # add sudo before a command if the user is not root
+    if not general.check_root():
         full_cmd.append('sudo')
     full_cmd.extend(command)
     for arg in extra:


### PR DESCRIPTION
This PR brings in changes to run extensions with elevated privileges. We do this because most container images have files owned by root. File scanners cannot read these files if they are run by a non-root user.