### PR TITLE
Fix pep8/pylint prospector errors

### DIFF
--- a/tern/__main__.py
+++ b/tern/__main__.py
@@ -14,7 +14,6 @@ import logging
 import os
 import sys
 
-from tern.analyze import common
 from tern.analyze.docker import run
 from tern.utils import cache
 from tern.utils import constants
@@ -87,13 +86,13 @@ def do_main(args):
         if args.dockerfile:
             run.execute_dockerfile(args)
         if args.docker_image:
-            if common.check_tar(args.docker_image):
+            if general.check_tar(args.docker_image):
                 logger.error("%s", errors.incorrect_raw_option)
             else:
                 run.execute_docker_image(args)
                 logger.debug('Report completed.')
         if args.raw_image:
-            if not common.check_tar(args.raw_image):
+            if not general.check_tar(args.raw_image):
                 logger.error("%s", errors.invalid_raw_image.format(
                     image=args.raw_image))
             else:

--- a/tern/analyze/common.py
+++ b/tern/analyze/common.py
@@ -9,7 +9,6 @@ Common functions
 
 import logging
 import os
-import tarfile
 
 from tern.classes.package import Package
 from tern.classes.notice import Notice
@@ -453,11 +452,3 @@ def get_os_style(image_layer, binary):
                     package_manager=binary,
                     package_format=image_layer.pkg_format,
                     os_list=image_layer.os_guess), 'info'))
-
-
-def check_tar(tar_file):
-    '''Check if provided file is a valid tar archive file'''
-    if os.path.exists(tar_file):
-        if tarfile.is_tarfile(tar_file):
-            return True
-    return False

--- a/tern/analyze/docker/container.py
+++ b/tern/analyze/docker/container.py
@@ -16,7 +16,6 @@ import requests
 import sys
 import time
 
-from tern.analyze import common
 from tern.utils.constants import container
 from tern.utils.constants import logger_name
 from tern.utils.constants import temp_tarfile
@@ -148,7 +147,7 @@ def extract_image_metadata(image_tag_string):
     temp_path = rootfs.get_working_dir()
     placeholder = os.path.join(general.get_top_dir(), temp_tarfile)
     try:
-        if common.check_tar(image_tag_string) is True:
+        if general.check_tar(image_tag_string) is True:
             # image_tag_string is the path to the tar file for raw images
             rootfs.extract_tarfile(image_tag_string, temp_path)
         else:

--- a/tern/analyze/docker/dockerfile.py
+++ b/tern/analyze/docker/dockerfile.py
@@ -47,9 +47,7 @@ def get_command_list(dockerfile_name):
         # check if this line is a continuation of the previous line
         # it should not be a comment
         if command_cont:
-            if comments.match(line):
-                continue
-            else:
+            if comments.match(line) is not None:
                 command = command + line
         # check if this line has an indentation
         # comments don't count

--- a/tern/classes/docker_image.py
+++ b/tern/classes/docker_image.py
@@ -99,7 +99,7 @@ class DockerImage(Image):
         '''Given the manifest, return the list of image tag strings'''
         return manifest[0].get('RepoTags')
 
-    def get_layer_sha(layer_path):
+    def get_layer_sha(self, layer_path):
         '''Docker's layers are file paths starting with the ID.
         Get just the sha'''
         return os.path.dirname(layer_path)

--- a/tern/classes/image.py
+++ b/tern/classes/image.py
@@ -108,7 +108,6 @@ class Image:
         '''Load image metadata
         Currently there is no standard way to do this. For a specific tool,
         Inherit from this class and override this method'''
-        pass
 
     def to_dict(self, template=None):
         '''Return a dictionary representation of the image'''
@@ -150,4 +149,3 @@ class Image:
     def get_download_location(self):
         '''Return the registry information from where the image came from.
         Currently, the image's metadata doesn't have this information'''
-        pass

--- a/tern/classes/image_layer.py
+++ b/tern/classes/image_layer.py
@@ -73,7 +73,7 @@ class ImageLayer:
     @property
     def created_by(self):
         return self.__created_by
-        
+
     @created_by.setter
     def created_by(self, create_string):
         self.__created_by = create_string
@@ -120,11 +120,11 @@ class ImageLayer:
             self.__analyzed_output = analyzed_output
         else:
             raise ValueError('analyzed_output should be a string')
-    
+
     @property
     def files_analyzed(self):
         return self.__files_analyzed
-        
+
     @files_analyzed.setter
     def files_analyzed(self, x):
         if isinstance(x, bool):
@@ -138,7 +138,7 @@ class ImageLayer:
                 self.__packages.append(package)
         else:
             raise TypeError('Object type is {0}, should be Package'.format(
-                       type(package)))
+                            type(package)))
 
     def remove_package(self, package_name):
         rem_index = 0

--- a/tern/classes/notice.py
+++ b/tern/classes/notice.py
@@ -8,7 +8,6 @@ from tern.utils.general import prop_names
 
 class NoticeException(Exception):
     '''Base notice exception'''
-    pass
 
 
 class LevelException(NoticeException):

--- a/tern/classes/package.py
+++ b/tern/classes/package.py
@@ -88,7 +88,7 @@ class Package:
 
     @checksum.setter
     def checksum(self, checksum):
-        self.__checksum = checksum;
+        self.__checksum = checksum
 
     def to_dict(self, template=None):
         '''Return a dictionary version of the Package object

--- a/tern/formats/spdx/spdxtagvalue/generator.py
+++ b/tern/formats/spdx/spdxtagvalue/generator.py
@@ -256,7 +256,7 @@ class SpdxTagValue(generator.Generate):
                 if ('PackageLicenseDeclared' in package_dict.keys() and
                         package_obj.pkg_license):
                     package_dict['PackageLicenseDeclared'] = \
-                       get_license_ref(package_obj.pkg_license)
+                        get_license_ref(package_obj.pkg_license)
                 if ('PackageCopyrightText' in package_dict.keys() and
                         package_obj.copyright):
                     package_dict['PackageCopyrightText'] = \

--- a/tern/report/report.py
+++ b/tern/report/report.py
@@ -19,7 +19,6 @@ from stevedore.exception import NoMatches
 from tern.report import errors
 from tern.report import formats
 from tern.analyze.docker import container
-from tern.analyze import common
 from tern.utils import constants
 from tern.utils import cache
 from tern.utils import general
@@ -52,7 +51,7 @@ def setup(dockerfile=None, image_tag_string=None):
     if dockerfile:
         dhelper.load_docker_commands(dockerfile)
     # check if the docker image is present
-    if image_tag_string and common.check_tar(image_tag_string) is False:
+    if image_tag_string and general.check_tar(image_tag_string) is False:
         if not container.check_image(image_tag_string):
             # if no docker image is present, try to pull it
             if not container.pull_image(image_tag_string):

--- a/tern/utils/general.py
+++ b/tern/utils/general.py
@@ -6,6 +6,7 @@
 import os
 import random
 import re
+import tarfile
 import subprocess  # nosec
 from contextlib import contextmanager
 from pathlib import Path
@@ -123,3 +124,11 @@ def prop_names(obj):
         prop_name = re.sub(priv_name, '', key)
         prop_name = re.sub(prop_decorators, '', prop_name, 1)
         yield key, prop_name
+
+
+def check_tar(tar_file):
+    '''Check if provided file is a valid tar archive file'''
+    if os.path.exists(tar_file):
+        if tarfile.is_tarfile(tar_file):
+            return True
+    return False


### PR DESCRIPTION
This series of commits fixes a handful of pylint/pep8 errors discovered by the latest version of prospector (1.2.0).

After running prospector in Tern's root directory with these changes, there are no longer an prospector error messages.

Fixes #513 

Signed-off-by: Rose Judge <rjudge@vmware.com>