### PR TITLE
circleci: Update prospector profile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
     # steps to run Prospector
     steps:
       - setup
-      - run: pip install prospector>=1.1 GitPython~=2.1
+      - run: pip install prospector>=1.2 GitPython~=2.1
       - run: pip install .
       - run: c=`python ci/evaluate_docs.py`; if [ -z $c ]; then echo "No .py files to lint"; else echo $c | xargs prospector; fi
   # security linting using Bandit

--- a/.prospector.yaml
+++ b/.prospector.yaml
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+# Copyright © 2020, VMware, Inc.  All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+strictness: medium
+test-warnings: false
+
+pep8:
+  full: true
+
+pep257:
+  run: false


### PR DESCRIPTION
This commit makes three changes:

1) Bumps the minimum version of prospector installed on the circleci VMs
   from 1.1 to 1.2.

2) Adds a prospector.yaml profile to increase prospector code linting
   and control the checks and their strictness.
   This yaml file takes suggestions from Michael Rohan in
   https://github.com/vmware/tern/pull/356.

See also #513

Signed-off-by: Rose Judge <rjudge@vmware.com>