### PR TITLE
Add 'apt' to Command Library

### DIFF
--- a/tern/command_lib/snippets.yml
+++ b/tern/command_lib/snippets.yml
@@ -13,6 +13,13 @@ apt-get:
     - 'update' 
   packages: 'dpkg' # refer to base.yml's method of collection
 
+apt:
+  install: 'install' # subcommand to install
+  remove: 'purge' # subcommand to remove a package
+  ignore: # list of subcommands that don't add or remove packages
+    - 'update' 
+  packages: 'dpkg' # refer to base.yml's method of collection
+
 tyum:
   install: 'install'
   remove: 'remove'


### PR DESCRIPTION
This change adds the 'apt' command to the snippets.yml allowing TERN
to correctly process layers added using 'apt' command.

resolves: #512 

Signed-off-by: oc37ejuc <oc37ejuc@users.noreply.github.com>