### PR TITLE
Bump prospector version and disable pep8 N802

### DIFF
--- a/.prospector.yaml
+++ b/.prospector.yaml
@@ -7,6 +7,8 @@ test-warnings: false
 
 pep8:
   full: true
+  disable:
+    - N802 # pep8-naming: function name should be lower case
 
 pep257:
   run: false

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,4 +54,4 @@ console_scripts =
     tern = tern.__main__:main
 
 [options.extras_require]
-dev = bandit~=1.6; prospector>=1.1; GitPython~=2.1
+dev = bandit~=1.6; prospector>=1.2; GitPython~=2.1


### PR DESCRIPTION
- Bump up prospector version in the develpment requirements so
it matches the version that we use on CI.
- Disable N802 check - function name should be lower case. We do
this because unittest in particular wants the functions to be in
CamelCase or else it is unable to identify them during testing.

Signed-off-by: Nisha K <nishak@vmware.com>