### PR TITLE
setup.py: Discover tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,15 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 from setuptools import setup
+import unittest
+
+
+def get_test_suite():
+    return unittest.TestLoader().discover('tests', 'test_*.py')
 
 
 setup(
     setup_requires=['pbr'],
     pbr=True,
-    test_suite="tests.runtests",
+    test_suite="setup.get_test_suite",
 )


### PR DESCRIPTION
This PR makes it possible for the tests
to be discovered correctly by adding
a function get_test_suite in setup.py.

Closes https://github.com/vmware/tern/issues/406
Signed-off-by: PrajwalM2212 <prajwalmmath@gmail.com>