### PR TITLE
Remove coverage --fail-under flag

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -36,4 +36,4 @@ jobs:
           pip install coverage
           pip install .
           coverage run -m unittest discover -s tests
-          coverage report --fail-under 85
+          coverage report


### PR DESCRIPTION
There is only 63% test coverage for Tern's code base right now but
the coverage threshold is currently set to fail below 85% coverage.
This means that all PRs are currently failing the coverage check.

This commit removes the 'fail-under' flag when running the coverage
command for GitHub Action pull requests. Once Tern's coverage is up
higher we can re-add this flag for pull requests.

Signed-off-by: Rose Judge <rjudge@vmware.com>