### PR TITLE
Add new class FileData

### DIFF
--- a/ci/test_files_touched.py
+++ b/ci/test_files_touched.py
@@ -49,6 +49,8 @@ test_suite = {
     ['python tests/test_class_command.py'],
     re.compile('tern/classes/docker_image.py'):
     ['tern -l report -i photon:3.0'],
+    re.compile('tern/classes/file_data.py'):
+    ['python tests/test_class_file_data.py'],
     re.compile('tern/classes/image.py'):
     ['python tests/test_class_image.py'],
     re.compile('tern/classes/image_layer.py'):
@@ -95,6 +97,8 @@ test_suite = {
         ['python tests/test_class_command.py'],
     re.compile('tests/test_class_docker_image.py'):
         ['python tests/test_class_docker_image.py'],
+    re.compile('tests/test_class_file_data.py'):
+        ['python tests/test_class_file_data.py'],
     re.compile('tests/test_class_image.py'):
         ['python tests/test_class_image.py'],
     re.compile('tests/test_class_image_layer.py'):

--- a/tern/classes/file_data.py
+++ b/tern/classes/file_data.py
@@ -1,0 +1,142 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+import datetime
+
+from tern.classes.origins import Origins
+from tern.utils.general import prop_names
+
+
+class FileData:
+    '''A file existing within a container image layer
+    If any file level analysis is done then most of the attributes can be
+    filled up. If no analysis is done, we would still have at the minimum the
+    file name and path
+    attributes:
+        name: file name
+        path: path to the file
+        date: the creation date of the file
+        checksum_type: the digest algorithm used to create the file checksum
+        checksum: the checksum
+        version_control: the type of version control tool used. Left blank if
+        the file was downloaded using a package manager or from a website.
+        version: the version of the file under version control. If it came
+        with a package the version would be the same as the package version.
+        file_type: this is a string describing what type of file this is
+        licenses: A list of licenses that may be detected or is known
+        license_expressions: This is a SPDX term used to describe how one or
+        more licenses together should be understood. This list may be left
+        blank.
+        copyrights: a list of copyright strings
+        authors: a list of authors if known
+        packages: a list of packages where this file could come from
+        urls: a list of urls from where this file could come from
+
+    methods:
+        to_dict: returns a dictionary representation of the instance
+        set_version: set the version of the file given the version control
+        system used
+        set_checksum: set the checksum of the file given the checksum type'''
+    def __init__(self,
+                 name,
+                 path,
+                 date='',
+                 file_type=''):
+        self.__name = name
+        self.__path = path
+        self.date = date
+        self.__file_type = file_type
+        self.__checksum_type = ''
+        self.__checksum = ''
+        self.__version_control = ''
+        self.__version = ''
+        self.licenses = []
+        self.license_expressions = []
+        self.copyrights = []
+        self.authors = []
+        self.packages = []
+        self.urls = []
+        self.__origins = Origins()
+
+    @property
+    def name(self):
+        return self.__name
+
+    @property
+    def path(self):
+        return self.__path
+
+    @property
+    def date(self):
+        return self.__date
+
+    @date.setter
+    def date(self, date):
+        '''Set the date if a date string exists'''
+        if date:
+            try:
+                datetime.datetime.strptime(date, '%Y-%m-%d')
+            except ValueError:
+                raise ValueError("Incorrect date format, should be YYYY-MM-DD")
+        self.__date = date
+
+    @property
+    def checksum_type(self):
+        return self.__checksum_type
+
+    @property
+    def checksum(self):
+        return self.__checksum
+
+    @property
+    def version_control(self):
+        return self.__version_control
+
+    @property
+    def version(self):
+        return self.__version
+
+    @property
+    def file_type(self):
+        return self.__file_type
+
+    @property
+    def origins(self):
+        return self.__origins
+
+    def set_checksum(self, checksum_type='', checksum=''):
+        '''Set the checksum type and checksum of the file'''
+        # TODO: calculate the checksum if not given
+        self.__checksum_type = checksum_type
+        self.__checksum = checksum
+
+    def set_version(self, version_control='', version=''):
+        '''Set the version control and version of the file'''
+        # TODO: find the version given the version control system
+        self.__version_control = version_control
+        self.__version = version
+
+    def to_dict(self, template=None):
+        '''Return a dictionary version of the FileData object
+        If given an object which is a subclass of Template then map
+        the keys to the FileData class properties'''
+        file_dict = {}
+        if template:
+            # loop through object properties
+            for key, prop in prop_names(self):
+                # check if the property is in the mapping
+                if prop in template.file_data().keys():
+                    file_dict.update(
+                        {template.file_data()[prop]: self.__dict__[key]})
+            # update the 'origins' part if it exists in the mapping
+            if 'origins' in template.file_data().keys():
+                file_dict.update(
+                    {template.file_data()['origins']: self.origins.to_dict()})
+        else:
+            # don't map, just use the property name as the key
+            for key, prop in prop_names(self):
+                file_dict.update({prop: self.__dict__[key]})
+            file_dict.update({'origins': self.origins.to_dict()})
+        return file_dict

--- a/tern/classes/template.py
+++ b/tern/classes/template.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2017-2020 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
 from abc import ABCMeta
@@ -19,6 +19,10 @@ class Template(metaclass=ABCMeta):
             notice: mappings for the properties under 'Notice'
             notice_origin: mappings for the properties under 'NoticeOrigin'
             origins: mappings for the properties under 'Origins' '''
+
+    @abstractmethod
+    def file_data(self):
+        '''Must implement a mapping for 'FileData' class properties'''
 
     @abstractmethod
     def package(self):

--- a/tests/test_class_file_data.py
+++ b/tests/test_class_file_data.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+import unittest
+
+from tern.classes.file_data import FileData
+from test_fixtures import TestTemplate1
+from test_fixtures import TestTemplate2
+
+
+class TestClassFileData(unittest.TestCase):
+
+    def setUp(self):
+        self.afile = FileData('afile',
+                              'path/to/afile')
+        self.afile.licenses = ['MIT', 'GPL']
+
+    def tearDown(self):
+        del self.afile
+
+    def testInstance(self):
+        file1 = FileData('file1', 'path/to/file1')
+        self.assertEqual(file1.name, 'file1')
+        self.assertEqual(file1.path, 'path/to/file1')
+        self.assertFalse(file1.checksum_type)
+        self.assertFalse(file1.checksum)
+        self.assertFalse(file1.date)
+        self.assertFalse(file1.version_control)
+        self.assertFalse(file1.version)
+        self.assertFalse(file1.file_type)
+        self.assertFalse(file1.licenses)
+        self.assertFalse(file1.license_expressions)
+        self.assertFalse(file1.copyrights)
+        self.assertFalse(file1.authors)
+        self.assertFalse(file1.packages)
+        self.assertFalse(file1.urls)
+
+        with self.assertRaises(ValueError):
+            file2 = FileData('file2',
+                             'path/to/file2',
+                             '12355')
+        file2 = FileData('file2',
+                         'path/to/file2',
+                         '2020-01-01',
+                         'binary')
+        self.assertEqual(file2.date, '2020-01-01')
+        self.assertEqual(file2.file_type, 'binary')
+
+        file2.licenses = ['MIT', 'GPL']
+        file2.license_expressions = ['GPLv2 or MIT', 'MIT and GPLv2']
+        file2.copyrights = ['copyrights']
+        file2.authors = ['author1', 'author2']
+        file2.packages = ['package1', 'package2']
+        self.assertEqual(file2.licenses, ['MIT', 'GPL'])
+        self.assertEqual(file2.license_expressions, ['GPLv2 or MIT',
+                                                     'MIT and GPLv2'])
+        self.assertEqual(file2.copyrights, ['copyrights'])
+        self.assertEqual(file2.authors, ['author1', 'author2'])
+        self.assertEqual(file2.packages, ['package1', 'package2'])
+
+    def testSetChecksum(self):
+        self.afile.set_checksum('sha256', '12345abcde')
+        self.assertEqual(self.afile.checksum_type, 'sha256')
+        self.assertEqual(self.afile.checksum, '12345abcde')
+
+    def testSetVersion(self):
+        self.afile.set_version('git', '12345abcde')
+        self.assertEqual(self.afile.version_control, 'git')
+        self.assertEqual(self.afile.version, '12345abcde')
+
+    def testToDict(self):
+        file_dict = self.afile.to_dict()
+        self.assertEqual(file_dict['name'], 'afile')
+        self.assertEqual(file_dict['path'], 'path/to/afile')
+        self.assertEqual(file_dict['licenses'], ['MIT', 'GPL'])
+
+    def testToDictTemplate(self):
+        template1 = TestTemplate1()
+        template2 = TestTemplate2()
+        dict1 = self.afile.to_dict(template1)
+        dict2 = self.afile.to_dict(template2)
+        self.assertEqual(len(dict1.keys()), 3)
+        self.assertEqual(dict1['file.name'], 'afile')
+        self.assertEqual(dict1['file.path'], 'path/to/afile')
+        self.assertEqual(dict1['file.licenses'], ['MIT', 'GPL'])
+        self.assertFalse(dict2['notes'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2019-2020 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
 """
@@ -28,6 +28,11 @@ class TestImage(Image):
 
 class TestTemplate1(Template):
     '''Template with no origins mapping'''
+    def file_data(self):
+        return {'name': 'file.name',
+                'path': 'file.path',
+                'licenses': 'file.licenses'}
+
     def package(self):
         return {'name': 'package.name',
                 'version': 'package.version',
@@ -45,6 +50,14 @@ class TestTemplate1(Template):
 
 class TestTemplate2(Template):
     '''Template with origins mapping'''
+    def file_data(self):
+        mapping = {'name': 'file.name',
+                   'path': 'file.path',
+                   'licenses': 'file.licenses'}
+        # we update the mapping with another defined mapping
+        mapping.update(self.origins())
+        return mapping
+
     def package(self):
         mapping = {'name': 'package.name',
                    'version': 'package.version',

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -14,8 +14,8 @@ from tern.classes.template import Template
 
 
 class TestImage(Image):
-    def __init__(self, id):
-        super().__init__(id)
+    def __init__(self, image_id):
+        super().__init__(image_id)
 
     def load_image(self):
         l1 = ImageLayer('123abc', 'path/to/tar')


### PR DESCRIPTION
This begins work towards adding file level data to generated
reports.

FileData represents metadata for a file found in an image layer
filesystem. It is called FileData so as to not interfere with
python's builtin 'file'. We use scancode's data model for the
initial set of properties. These include: name, path, date, file_type,
licenses, license_expressions, copyrights, packages, urls,
checksum_type and checksum. We have additionally included
version_control and version to generally point to where the file
may have come from. This is useful if the file was added from a git
repository cloned on the host machine. We have also included an
'Origins' object to record any issues that may have happened during
analysis.

We also added a mapping in the Template class called file_data to
allow templating for reports.

Appropriate tests were created and added to the ci automation.

Resolves #476

Signed-off-by: Nisha K <nishak@vmware.com>