### PR TITLE
Extract sha digest of Docker image:tag

### DIFF
--- a/tern/analyze/docker/container.py
+++ b/tern/analyze/docker/container.py
@@ -77,23 +77,39 @@ def check_image(image_tag_string):
     logger.debug(
         "Checking if image \"%s\" is available on disk...", image_tag_string)
     try:
-        client.images.get(image_tag_string)
+        image = client.images.get(image_tag_string)
         logger.debug("Image \"%s\" found", image_tag_string)
-        return True
+        return image
     except docker.errors.ImageNotFound:
-        return False
+        return None
 
 
 def pull_image(image_tag_string):
     '''Try to pull an image from Dockerhub'''
     logger.debug("Attempting to pull image \"%s\"", image_tag_string)
     try:
-        client.images.pull(image_tag_string)
+        image = client.images.pull(image_tag_string)
         logger.debug("Image \"%s\" downloaded", image_tag_string)
-        return True
+        return image
     except docker.errors.ImageNotFound:
         logger.warning("No such image: \"%s\"", image_tag_string)
-        return False
+        return None
+
+
+def get_image(image_tag_string):
+    '''Try to get an image from Dockerhub.
+    image_tag_string: can be in image:tag or image@digest_type:digest format'''
+    check_docker_setup()
+    image = check_image(image_tag_string)
+    if image is None:
+        return pull_image(image_tag_string)
+    return image
+
+
+def get_image_digest(docker_image):
+    '''Given a docker image object return the digest information of the
+    unique image in 'image@sha_type:digest' format.'''
+    return docker_image.attrs['RepoDigests'][0]
 
 
 def build_container(dockerfile, image_tag_string):

--- a/tern/report/report.py
+++ b/tern/report/report.py
@@ -52,9 +52,9 @@ def setup(dockerfile=None, image_tag_string=None):
         dhelper.load_docker_commands(dockerfile)
     # check if the docker image is present
     if image_tag_string and general.check_tar(image_tag_string) is False:
-        if not container.check_image(image_tag_string):
+        if container.check_image(image_tag_string) is None:
             # if no docker image is present, try to pull it
-            if not container.pull_image(image_tag_string):
+            if container.pull_image(image_tag_string) is None:
                 logger.fatal("%s", errors.cannot_find_image.format(
                     imagetag=image_tag_string))
                 sys.exit()
@@ -88,9 +88,9 @@ def load_base_image():
     '''Create base image from dockerfile instructions and return the image'''
     base_image, dockerfile_lines = dhelper.get_dockerfile_base()
     # try to get image metadata
-    if not container.check_image(base_image.repotag):
+    if container.check_image(base_image.repotag) is None:
         # if no base image is found, give a warning and continue
-        if not container.pull_image(base_image.repotag):
+        if container.pull_image(base_image.repotag) is None:
             logger.warning("%s", errors.cannot_find_image.format(
                 imagetag=base_image.repotag))
     try:

--- a/tern/utils/general.py
+++ b/tern/utils/general.py
@@ -143,6 +143,8 @@ def check_root():
 
 
 def check_image_string(image_str: str):
+    '''Check if the image string is in the format image:tag or
+    image@digest_type:digest format. If not, return False.'''
     tag_format = r'.+:.+'
     digest_format = r'.+@.+:.+'
     if re.match(tag_format, image_str) or re.match(digest_format, image_str):


### PR DESCRIPTION
This commit adds two functions in dockerfile.py that will extract the
sha256 digest of an image given its name and tag using the Docker SDK
for Python. All changes are in tern/analyze/docker/dockerfile.py.

1) find_image_digest() takes an image name and tag and outputs the
   associated tag@sha:digest value from Docker. There are two digests
   that associate to an image -- a) the transport digest that shows
   when you run 'docker pull <image> on your local command line and
   b) The digest that you see if you were to navigate the dockerhub
   webui repository and look for the image. find_image_digest() will
   return the digest from option (a).

2) expand_from_images() will take a dockerfile object (created using
   get_dockerfile_obj() in dockerfile.py) and update the structure
   dictionary and parent_images list with the full tag@sha:digest
   value. It uses find_image_digest() to get the associated digest
   shas. This will be used later to "pin" a base image in a
   dockerfile. This works for multistage builds as well.

Works towards #507

Signed-off-by: Rose Judge <rjudge@vmware.com>