### PR TITLE
container: close the client socket

### DIFF
--- a/tern/analyze/docker/container.py
+++ b/tern/analyze/docker/container.py
@@ -165,3 +165,14 @@ def extract_image_metadata(image_tag_string):
             raise IOError('Unable to untar Docker image')
     except docker.errors.APIError:  # pylint: disable=try-except-raise
         raise
+
+
+def close_client():
+    '''End docker interactions by closing the client. This is meant to be
+    used after analysis is done'''
+    try:
+        client.close()
+    except requests.exceptions.ConnectionError:
+        # it should either already be closed or docker is not setup
+        # either way, the socket is closed
+        pass

--- a/tern/report/report.py
+++ b/tern/report/report.py
@@ -62,6 +62,8 @@ def setup(dockerfile=None, image_tag_string=None):
 
 def teardown():
     '''Tear down tern setup'''
+    # close docker client if any
+    container.close_client()
     # save the cache
     cache.save()
     # remove folders for rootfs operations

--- a/tests/test_class_docker_image.py
+++ b/tests/test_class_docker_image.py
@@ -45,6 +45,7 @@ class TestClassDockerImage(unittest.TestCase):
                            'in / ')
 
     def tearDown(self):
+        container.close_client()
         del self.image
 
     def testInstance(self):
@@ -52,8 +53,8 @@ class TestClassDockerImage(unittest.TestCase):
                                              '0752aa1ad7582c667704fda9f004cc4'
                                              'bfd8601fac7f2656c7567bb4')
         self.assertEqual(self.image.name, 'vmware/tern@sha256')
-        self.assertEqual(self.image.tag, '20b32a9a20752aa1ad7582c667704fda9f004c'
-                                         'c4bfd8601fac7f2656c7567bb4')
+        self.assertEqual(self.image.tag, '20b32a9a20752aa1ad7582c667704fda9f00'
+                                         '4cc4bfd8601fac7f2656c7567bb4')
         self.assertFalse(self.image.image_id)
         self.assertFalse(self.image.manifest)
         self.assertFalse(self.image.repotags)


### PR DESCRIPTION
The docker client socket is still open after running. We don't
want to leave this open. So closing it during teardown.

Signed-off-by: Nisha K <nishak@vmware.com>