### PR TITLE
formats: spdx: Add implementation for file_data

### DIFF
--- a/ci/test_files_touched.py
+++ b/ci/test_files_touched.py
@@ -64,7 +64,8 @@ test_suite = {
     re.compile('tern/classes/package.py'):
     ['python tests/test_class_package.py'],
     re.compile('tern/classes/template.py'):
-    ['python tests/test_class_template.py'],
+    ['python tests/test_class_template.py',
+     'tern -l report -f spdxtagvalue -i photon:3.0'],
     # tern/command_lib
     re.compile('tern/command_lib'): [
         'tern -l report -i photon:3.0',
@@ -84,6 +85,9 @@ test_suite = {
         'tern -l report -f json -i photon:3.0',
         'tern -l report -f spdxtagvalue -i photon:3.0',
         'tern -l report -d samples/alpine_python/Dockerfile'],
+    # tern/formats/spdx
+    re.compile('tern/formats/spdx'): [
+        'tern -l report -f spdxtagvalue -i photon:3.0'],
     # tern/tools
     re.compile('tern/tools'):
     ['tern -l report -i golang:alpine'],

--- a/tern/formats/spdx/spdx.py
+++ b/tern/formats/spdx/spdx.py
@@ -10,6 +10,10 @@ class SPDX(Template):
     '''This is the SPDX Template class
     It provides mappings for the SPDX tag-value document format'''
 
+    def file_data(self):
+        return {'name': 'FileName',
+                'file_type': 'FileType'}
+
     def package(self):
         return {'name': 'PackageName',
                 'version': 'PackageVersion',


### PR DESCRIPTION
Since the template class now requires an implementation for the
file_data method for any class that derives from it, the spdx
template needs to implement this method. Adding the implementation.

Also added a test to the ci which will run a test on the spdx template
if template.py changes.

Signed-off-by: Nisha K <nishak@vmware.com>