### PR TITLE
Add list of FileData objects to the ImageLayer class

### DIFF
--- a/tern/classes/template.py
+++ b/tern/classes/template.py
@@ -15,6 +15,7 @@ class Template(metaclass=ABCMeta):
             package: mappings for the properties under 'Package'
             layer: mappings for the properties under 'Layer'
             image: mappings for the properties under 'Image'
+            file_data: mappings for the properties under 'FileData'
         should implement:
             notice: mappings for the properties under 'Notice'
             notice_origin: mappings for the properties under 'NoticeOrigin'

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -41,7 +41,8 @@ class TestTemplate1(Template):
     def image_layer(self):
         return {'diff_id': 'layer.diff',
                 'tar_file': 'layer.tarfile',
-                'packages': 'layer.packages'}
+                'packages': 'layer.packages',
+                'files': 'layer.files'}
 
     def image(self):
         return {'image_id': 'image.id',
@@ -70,7 +71,8 @@ class TestTemplate2(Template):
     def image_layer(self):
         mapping = {'diff_id': 'layer.diff',
                    'tar_file': 'layer.tarfile',
-                   'packages': 'layer.packages'}
+                   'packages': 'layer.packages',
+                   'files': 'layer.files'}
         # we update the mapping with another defined mapping
         mapping.update(self.origins())
         return mapping


### PR DESCRIPTION
This PR adds:
1. files property to image_layer
2. implements add_file, remove_file, get_file_names_and_paths
methods
3. Adds files to to_dict method of image_layer
4. Adds tests for the changes made at test_class_image_layer
5. Modifies test_fixtures to account for files as well

Closes https://github.com/vmware/tern/issues/554

Signed-off-by: PrajwalM2212 <prajwalmmath@gmail.com>