### PR TITLE
classes: Add FileData object list to package class

### DIFF
--- a/tests/test_class_package.py
+++ b/tests/test_class_package.py
@@ -5,6 +5,7 @@
 
 import unittest
 
+from tern.classes.file_data import FileData
 from tern.classes.package import Package
 from test_fixtures import TestTemplate1
 from test_fixtures import TestTemplate2
@@ -60,7 +61,42 @@ class TestClassPackage(unittest.TestCase):
         self.assertEqual(self.p1.download_url, 'https://github.com')
         self.assertEqual(self.p1.checksum, '123abc456')
 
+    def testAddFile(self):
+        p1 = Package('package')
+        f1 = FileData('test.java', 'abc/pqr/test.java')
+        f2 = FileData('test.c', 'abc/pqr/test.c')
+        p1.add_file(f1)
+        p1.add_file(f2)
+        self.assertEqual(len(p1.files), 2)
+        with self.assertRaises(TypeError):
+            p1.add_file('sample.cpp')
+
+    def testRemoveFile(self):
+        p1 = Package('package')
+        f1 = FileData('test.java', 'abc/pqr/test.java')
+        f2 = FileData('test.c', 'abc/pqr/test.c')
+        p1.add_file(f1)
+        p1.add_file(f2)
+        self.assertTrue(p1.remove_file('abc/pqr/test.java'))
+        self.assertEqual(len(p1.files), 1)
+        self.assertTrue(p1.remove_file('abc/pqr/test.c'))
+        self.assertEqual(len(p1.files), 0)
+        self.assertFalse(p1.remove_file('abc'))
+
+    def testGetFilePaths(self):
+        p1 = Package('package')
+        f1 = FileData('test.java', 'abc/pqr/test.java')
+        f2 = FileData('test.c', 'abc/pqr/test.c')
+        p1.add_file(f1)
+        p1.add_file(f2)
+        self.assertEqual(p1.get_file_paths(),
+                         ['abc/pqr/test.java',
+                          'abc/pqr/test.c'
+                          ])
+
     def testToDict(self):
+        f1 = FileData('test.java', 'abc/pqr/test.java')
+        self.p1.add_file(f1)
         a_dict = self.p1.to_dict()
         self.assertEqual(a_dict['name'], 'p1')
         self.assertEqual(a_dict['version'], '1.0')
@@ -70,17 +106,25 @@ class TestClassPackage(unittest.TestCase):
         self.assertEqual(a_dict['download_url'], 'https://github.com')
         self.assertFalse(a_dict['origins'])
         self.assertEqual(a_dict['checksum'], '123abc456')
+        self.assertEqual(a_dict['files'][0]['name'], 'test.java')
+        self.assertEqual(a_dict['files'][0]['path'], 'abc/pqr/test.java')
 
     def testToDictTemplate(self):
         template1 = TestTemplate1()
         template2 = TestTemplate2()
+        f1 = FileData('test.java', 'abc/pqr/test.java')
+        self.p1.add_file(f1)
         dict1 = self.p1.to_dict(template1)
         dict2 = self.p1.to_dict(template2)
-        self.assertEqual(len(dict1.keys()), 3)
+        self.assertEqual(len(dict1.keys()), 4)
         self.assertEqual(dict1['package.name'], 'p1')
+        self.assertEqual(dict1['package.files'][0]['file.name'],
+                         'test.java')
         self.assertEqual(dict1['package.version'], '1.0')
         self.assertEqual(dict1['package.license'], 'Apache 2.0')
-        self.assertEqual(len(dict2.keys()), 5)
+        self.assertEqual(dict1['package.files'][0]['file.path'],
+                         'abc/pqr/test.java')
+        self.assertEqual(len(dict2.keys()), 6)
         self.assertFalse(dict2['notes'])
 
     def testIsEqual(self):
@@ -112,7 +156,7 @@ class TestClassPackage(unittest.TestCase):
         self.assertFalse(p.proj_url)
         self.assertEqual(len(p.origins.origins), 1)
         self.assertEqual(p.origins.origins[0].origin_str, 'p1')
-        self.assertEqual(len(p.origins.origins[0].notices), 3)
+        self.assertEqual(len(p.origins.origins[0].notices), 4)
         self.assertEqual(p.origins.origins[0].notices[0].message,
                          "No metadata for key: copyright")
         self.assertEqual(p.origins.origins[0].notices[0].level, 'warning')

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -36,7 +36,8 @@ class TestTemplate1(Template):
     def package(self):
         return {'name': 'package.name',
                 'version': 'package.version',
-                'pkg_license': 'package.license'}
+                'pkg_license': 'package.license',
+                'files': 'package.files'}
 
     def image_layer(self):
         return {'diff_id': 'layer.diff',
@@ -62,7 +63,8 @@ class TestTemplate2(Template):
         mapping = {'name': 'package.name',
                    'version': 'package.version',
                    'pkg_license': 'package.license',
-                   'proj_url': 'package.url'}
+                   'proj_url': 'package.url',
+                   'files': 'package.files'}
         # we update the mapping with another defined mapping
         mapping.update(self.origins())
         return mapping


### PR DESCRIPTION
 This PR adds files property to package class. It adds add_file, remove_file, get_file_paths methods. Tests have been added for the changes made. The to_dict method has also been changed to account for the new files property

Closes https://github.com/vmware/tern/issues/559

Signed-off-by: PrajwalM2212 <prajwalmmath@gmail.com>