### PR TITLE
Parse package name from version

### DIFF
--- a/tern/classes/command.py
+++ b/tern/classes/command.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2017-2020 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
+import re
 from tern.utils.general import parse_command
 
 
@@ -140,3 +141,13 @@ class Command:
             return False
         raise TypeError('Object type is {0}, should be Command'.format(
             type(other)))
+
+    def get_pkg_name(self, word, separators):
+        '''Given a package word and package manager separator character list,
+        parse the package name from the version and return the name.'''
+        if separators[0] == '-':
+            for i, char in enumerate(word):
+                if i < len(word):
+                    if char == separators[0] and word[i+1].isdigit():
+                        return word[:i]
+        return re.match(r'^[a-z-_A-Z\d]*', word).group()

--- a/tern/command_lib/base.yml
+++ b/tern/command_lib/base.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2017-2020 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 #
 # Known package listings for base images
@@ -6,6 +6,8 @@
 # <package manager>:
 #   pkg_format: <the package format used by the package manager>
 #   shell: <the shell executable> (needed if entering code snippets)
+#   pkg_separators: Potential characters to separate package name from version. Some package managers will have more than one.
+#   pinning_separator: Character to denote package version in pinned Dockerfile (i.e. apk add package=version)
 #   names: <a list of package names>
 #     invoke: (if this is a script to invoke include this)
 #       1:
@@ -22,6 +24,9 @@ tdnf:
   path:
     - 'usr/bin/tdnf' # don't put forward slash here as os.path.join will think it is the root directory on the host
   shell: '/usr/bin/bash'
+  pkg_separators:
+    - '-'
+  pinning_separator: '-'
   names:
     invoke:
       1:
@@ -65,6 +70,9 @@ dpkg:
   path:
     - 'usr/bin/dpkg'
   shell: '/bin/bash'
+  pkg_separators:
+    - '='
+  pinning_separator: '='
   # either enter the package names as a list or a snippet to invoke either within or outside the container
   names:
     invoke:
@@ -98,6 +106,9 @@ apk:
   path:
     - 'sbin/apk'
   shell: '/bin/sh'
+  pkg_separators:
+    - '='
+  pinning_separator: '='
   names:
     invoke:
       1:
@@ -136,6 +147,9 @@ pacman:
   path:
     - 'usr/bin/pacman'
   shell: '/usr/bin/sh'
+  pkg_separators:
+    - '='
+  pinning_separator: '='
   names:
     invoke:
       1:
@@ -172,6 +186,9 @@ rpm:
   path:
     - 'usr/bin/rpm'
   shell: '/usr/bin/sh'
+  pkg_separators:
+    - '-'
+  pinning_separator: '-'
   names:
     invoke:
       1:

--- a/tern/command_lib/snippets.yml
+++ b/tern/command_lib/snippets.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2017-2020 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 #
 # general commands to be invoked when retrieving package information
@@ -54,4 +54,7 @@ dnf:
     - 'check-update'
     - 'clean'
   packages: 'rpm'
-
+rpm:
+   install: '-i'
+   remove: '-e'
+   packages: 'rpm'

--- a/tests/test_class_command.py
+++ b/tests/test_class_command.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2017-2020 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
 import unittest
 
 from tern.classes.command import Command
+from tern.analyze.common import get_installed_package_names
 
 
 class TestClassCommand(unittest.TestCase):
@@ -16,6 +17,9 @@ class TestClassCommand(unittest.TestCase):
         self.download = Command('wget url')
         self.remove = Command('apt-get purge git')
         self.install2 = Command('apt-get install -y ca-certificates')
+        self.pinned1 = Command('apt-get install python3 zlib1g-dev=4.52.1')
+        self.pinned2 = Command('apt-get install ca-certificates:ppc64=2018i')
+        self.pinned3 = Command('yum install libncurses5-dev syslog-ng-1-2.3')
 
     def tearDown(self):
         del self.install
@@ -23,6 +27,9 @@ class TestClassCommand(unittest.TestCase):
         del self.download
         del self.remove
         del self.install2
+        del self.pinned1
+        del self.pinned2
+        del self.pinned3
 
     def testInstance(self):
         self.assertEqual(self.install.shell_command, 'apt-get install -y git')
@@ -121,6 +128,16 @@ class TestClassCommand(unittest.TestCase):
         # try to merge some other object
         with self.assertRaises(TypeError):
             self.install.merge('test')
+
+    def getPackageName(self):
+        list1 = get_installed_package_names(self.pinned1)
+        list2 = get_installed_package_names(self.pinned2)
+        list3 = get_installed_package_names(self.pinned3)
+        self.assertTrue(self.get_pkg_name(list1[0], '='), 'python3')
+        self.assertTrue(self.get_pkg_name(list1[1], '='), 'zlib1g-dev')
+        self.assertTrue(self.get_pkg_name(list2[0], '='), 'ca-certificates')
+        self.assertTrue(self.get_pkg_name(list3[0], '-'), 'libncurses5-dev')
+        self.assertTrue(self.get_pkg_name(list3[1], '-'), 'syslog-ng')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This commit adds the following functionality to the following files as
well as updating the copyright years in them.

tern/classes/command.py
   Adds a get_pkg_name() function to the command class. This function
   takes a word from a dockerfile command and separator list to
   separate the packge from its version by. For all but one separator,
   the function will use regex to split the pacakge from its version.
   In the case of the '-' separator, the function will loop through
   the characters in the word to determine package version. In either
   case, it will return the package name. This will be helpful in
   the upcoming dockerfile freeze functionality when we want to use
   the package manager to find the version of a package installed,
   regardless of the package that is specified in the dockerfile.

tests/test_class_command.py
   Add a test to test get_pkg_name() from the command class.

tern/command_lib/base.yml
   Add a package manager separator character list that would be used
   in a dockerfile to to denote a specific package version to install,
   for example, in 'apk add package=version', '=' is the separator
   character. Also add a 'pinning_separator' string associated with
   each package manager that will be used to "freeze" pacakge
   versions in the pinned dockerfile returned to the user.

tern/command_lib/snippets.yml
   Add 'rpm' snippet as a general command to retrieve package
   information.

Resolves #2
Works towards #506
