### PR TITLE
Record git project name and sha

### DIFF
--- a/tern/analyze/common.py
+++ b/tern/analyze/common.py
@@ -9,6 +9,7 @@ Common functions
 
 import logging
 import os
+import subprocess  # nosec
 
 from tern.classes.package import Package
 from tern.classes.notice import Notice
@@ -452,3 +453,59 @@ def get_os_style(image_layer, binary):
                     package_manager=binary,
                     package_format=image_layer.pkg_format,
                     os_list=image_layer.os_guess), 'info'))
+
+
+def check_git_src(dockerfile_path):
+    '''Given the src_path and the dockerfile path, return the git
+    repository name and sha information in the format of string.
+    Currently we only consider the following situation:
+    - target_git_project
+        - dir1
+        - dir2/dockerfile
+    So we only use dockerfile_path to find the git repo info.'''
+    # get the path of the folder containing the dockerfile
+    dockerfile_folder_path = os.path.dirname(dockerfile_path)
+    # locate the top level directory
+    path_to_toplevel = get_git_toplevel(dockerfile_folder_path)
+    # get the path of the target folder or file
+    logger.debug('looking into path: %s for git repo.', path_to_toplevel)
+    comment_line = ''
+    if path_to_toplevel:
+        sha_info = get_git_sha(path_to_toplevel)
+        # if path_to_toplevel exists, name_info should be the folder name
+        name_info = os.path.basename(path_to_toplevel)
+        comment_line = ('git project name: ' + name_info +
+                        ', HEAD sha: ' + sha_info)
+    else:
+        comment_line = 'Not a git repository'
+    return comment_line
+
+
+def get_git_sha(path_to_toplevel):
+    '''Given a absolute path to a git repository, return the HEAD sha.'''
+    command = ['git', 'rev-parse', 'HEAD']
+    sha_info = '(not found)'
+    try:
+        output = subprocess.check_output(  # nosec
+            command, stderr=subprocess.DEVNULL, cwd=path_to_toplevel)
+        if isinstance(output, bytes):
+            sha_info = output.decode('utf-8').split('\n').pop(0)
+    except subprocess.CalledProcessError:
+        logger.debug("Cannot find git repo sha, toplevel path is %s",
+                     path_to_toplevel)
+    return sha_info
+
+
+def get_git_toplevel(path):
+    '''Give a path, return the absolute path to the top level directory if it
+    is in a git repository. Empty string will be returned if not.'''
+    command = ['git', 'rev-parse', '--show-toplevel']
+    path_to_toplevel = ''
+    try:
+        output = subprocess.check_output(  # nosec
+            command, stderr=subprocess.DEVNULL, cwd=path)
+        if isinstance(output, bytes):
+            path_to_toplevel = output.decode('utf-8').split('\n').pop(0)
+    except subprocess.CalledProcessError:
+        logger.debug("Cannot find git repo toplevel, path is %s", path)
+    return path_to_toplevel

--- a/tests/dockerfiles/pin_add_command_test/pin_add_command_test_dockerfile
+++ b/tests/dockerfiles/pin_add_command_test/pin_add_command_test_dockerfile
@@ -1,0 +1,2 @@
+FROM ubuntu
+ADD plain_file /tmp

--- a/tests/dockerfiles/pin_add_command_test/plain_file
+++ b/tests/dockerfiles/pin_add_command_test/plain_file
@@ -1,0 +1,1 @@
+This is a test file.


### PR DESCRIPTION
This pr adds functions to the dockerfile parser. If the parser
comes across the ADD directive, record the git projeect name and
sha in a comment after the command.

This pr modifies utils/general.py and analyze/docker/dockerfile.py.

In dockerfile.py, function find_git_info recieve a line of ADD
command and the path to the parsed dockerfile. Function
expand_add_command receives a dfobj and iter it with find_git_info.

In general.py, function check_git_folder is used to find git info
in a folder and funtion check_git_tar in a tar file. Function
check_git_src looks into the src_path, and check the file type.

Work towards #509.