### PR TITLE
Add .tox and .coverage to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ report.json
 tern.log
 cache.yml
 vagrant/.*
+.tox
+.coverage


### PR DESCRIPTION
This change is to make sure .tox and .coverage don't get included
in a commit by accident.

Signed-off-by: Nisha K <nishak@vmware.com>