### PR TITLE
Update FileData object and scancode executor

### DIFF
--- a/tern/classes/file_data.py
+++ b/tern/classes/file_data.py
@@ -39,7 +39,8 @@ class FileData:
         to_dict: returns a dictionary representation of the instance
         set_version: set the version of the file given the version control
         system used
-        set_checksum: set the checksum of the file given the checksum type'''
+        set_checksum: set the checksum of the file given the checksum type
+        fill: fill data into the object instance from a dictionary'''
     def __init__(self,
                  name,
                  path,
@@ -194,3 +195,27 @@ class FileData:
         else:
             success = False
         return success
+
+    def merge(self, other):
+        '''Compare another FileData object to this instance. If the file path
+        is the same, we fill in the rest of the data excluding the checksum,
+        version control data and the extended attributes. This method can
+        be used in situations where an external scanner is used to collect
+        file level data that we don't collect ourselves'''
+        if not isinstance(other, FileData):
+            return False
+        if (self.path == other.path):
+            self.date = other.date
+            self.file_type = other.file_type
+            self.licenses = other.licenses
+            self.license_expressions = other.license_expressions
+            self.copyrights = other.copyrights
+            self.authors = other.authors
+            self.packages = other.packages
+            self.urls = other.urls
+            # collect notices
+            for o in other.origins.origins:
+                for n in o.notices:
+                    self.origins.add_notice_to_origins(o.origin_str, n)
+            return True
+        return False

--- a/tern/extensions/scancode/executor.py
+++ b/tern/extensions/scancode/executor.py
@@ -75,7 +75,7 @@ def analyze_file(layer_obj):
     # run scancode against each file
     command = 'scancode -ilpcu --quiet --json -'
     for fd in layer_obj.files:
-        full_cmd = get_file_command(layer_obj.tar_file, fd.path, command)
+        full_cmd = get_file_command(layer_obj.tar_file, fd, command)
         origin_file = 'File: ' + fd.path
         result, error = rootfs.shell_command(True, full_cmd)
         if not result:


### PR DESCRIPTION
This is work towards #480

The first commit fixes execution of the scancode extension.
The second commit adds a new method to the FileData
class along with a test.

Signed-off-by: Nisha K nishak@vmware.com