### PR TITLE
Integrate file level data from scancode

### DIFF
--- a/tern/classes/docker_image.py
+++ b/tern/classes/docker_image.py
@@ -7,9 +7,7 @@ import json
 import os
 import subprocess  # nosec
 
-from tern.classes.file_data import FileData
 from tern.utils import rootfs
-from tern.utils.cache import get_files
 from tern.utils.general import pushd
 from tern.utils.constants import manifest_file
 from tern.analyze.docker.container import extract_image_metadata
@@ -161,16 +159,6 @@ class DockerImage(Image):
             while layer_diffs and layer_paths:
                 layer = ImageLayer(layer_diffs.pop(0), layer_paths.pop(0))
                 layer.gen_fs_hash()
-                raw_file_list = get_files(layer.fs_hash)
-                # Fetch file info from cache if exists
-                # else extract and store file info
-                if raw_file_list:
-                    for file_dict in raw_file_list:
-                        file = FileData(file_dict['name'], file_dict['path'])
-                        file.fill(file_dict)
-                        layer.add_file(file)
-                else:
-                    layer.add_files()
                 self._layers.append(layer)
             self.set_layer_created_by()
         except NameError:  # pylint: disable=try-except-raise

--- a/tests/test_class_docker_image.py
+++ b/tests/test_class_docker_image.py
@@ -97,6 +97,8 @@ class TestClassDockerImage(unittest.TestCase):
 
     def testLayerFiles(self):
         self.image.load_image()
+        self.assertFalse(self.image.layers[0].files)
+        self.image.layers[0].add_files()
         for file in self.image.layers[0].files:
             self.assertTrue(
                 (file.name, file.path, file.checksum,


### PR DESCRIPTION
This resolves #480 

The first commit modifies loading and saving to the cache
for file level data.
The second commit modifies the executor for scancode to
leverage file level data caching and collection for an image.

Signed-off-by: Nisha K <nishak@vmware.com>