### PR TITLE
Include base OS value from /etc/os-release as part of Tern's data model

### DIFF
--- a/tern/analyze/common.py
+++ b/tern/analyze/common.py
@@ -100,10 +100,14 @@ def get_os_release():
                             constants.etc_release_path)
     lib_path = os.path.join(rootfs.get_working_dir(), constants.mergedir,
                             constants.lib_release_path)
+    tern_path = command_lib.base_file
     if not os.path.exists(etc_path):
         if not os.path.exists(lib_path):
-            return ''
-        etc_path = lib_path
+            if not tern_path:
+                return ''
+            etc_path = tern_path
+        else:
+            etc_path = lib_path
     # file exists at this point, try to read it
     with open(etc_path, 'r') as f:
         lines = f.readlines()


### PR DESCRIPTION
Obtain the `os_guess` value (as used in `common.get_os_style()`) from the path `tern/command_lib/base.yml` when `/etc/os-release` and `/usr/lib/os-release` do not exist.

Resolves: #524

Signed-off-by: Aditi Dutta <aditi011@e.ntu.edu.sg>