### PR TITLE
file_data.py: Add checksums property

### DIFF
--- a/tern/classes/file_data.py
+++ b/tern/classes/file_data.py
@@ -34,6 +34,7 @@ class FileData:
         authors: a list of authors if known
         packages: a list of packages where this file could come from
         urls: a list of urls from where this file could come from
+        checksums: a list of tuples of the form (checksum_type, checksum)
 
     methods:
         to_dict: returns a dictionary representation of the instance
@@ -61,6 +62,7 @@ class FileData:
         self.authors = []
         self.packages = []
         self.urls = []
+        self.__checksums = []
         self.__origins = Origins()
 
     @property
@@ -118,6 +120,14 @@ class FileData:
         self.__file_type = file_type
 
     @property
+    def checksums(self):
+        return self.__checksums
+
+    @checksums.setter
+    def checksums(self, checksums):
+        self.__checksums = checksums
+
+    @property
     def origins(self):
         return self.__origins
 
@@ -132,6 +142,11 @@ class FileData:
         # TODO: find the version given the version control system
         self.__version_control = version_control
         self.__version = version
+
+    def add_checksums(self, checksums):
+        '''Add checksum tuples to checksums property'''
+        for checksum in checksums:
+            self.__checksums.append(checksum)
 
     def to_dict(self, template=None):
         '''Return a dictionary version of the FileData object
@@ -185,6 +200,7 @@ class FileData:
             authors: <authors>
             packages: <packages>
             urls: <urls>
+            checksums: <checksums>
         the way to use this method is to instantiate the class with the
         name and path and then give it a file_data dictionary to fill
         in the rest return true if package name is the same as the one
@@ -213,6 +229,7 @@ class FileData:
             self.authors = other.authors
             self.packages = other.packages
             self.urls = other.urls
+            self.checksums = other.checksums
             # collect notices
             for o in other.origins.origins:
                 for n in o.notices:

--- a/tests/test_class_file_data.py
+++ b/tests/test_class_file_data.py
@@ -68,6 +68,14 @@ class TestClassFileData(unittest.TestCase):
         self.assertEqual(self.afile.checksum_type, 'sha256')
         self.assertEqual(self.afile.checksum, '12345abcde')
 
+    def testAddChecksums(self):
+        file1 = FileData('file1', 'path/to/file1')
+        file1.add_checksums([('SHA1', '12345abcde'),
+                             ('MD5', '1ff38cc592c4c5d0c8e3ca38be8f1eb1')])
+        self.assertEqual(file1.checksums,
+                         [('SHA1', '12345abcde'),
+                          ('MD5', '1ff38cc592c4c5d0c8e3ca38be8f1eb1')])
+
     def testExtAttrs(self):
         file = FileData('test.txt', 'usr/abc/test.txt')
         file.extattrs = '-rw-r--r--|1000|1000|19|1'
@@ -103,7 +111,9 @@ class TestClassFileData(unittest.TestCase):
             'checksum': '77304005ceb5f0d03ad4c37eb8386a10866e'
                         '4ceeb204f7c3b6599834c7319541',
             'extattrs': '-rw-r--r-- 1 1000 1000 16262 Nov 13 17:57'
-                        ' /usr/include/zconf.h'
+                        ' /usr/include/zconf.h',
+            'checksums': [('SHA1', '12345abcde'),
+                          ('MD5', '1ff38cc592c4c5d0c8e3ca38be8f1eb1')]
         }
         f = FileData('zconf.h', '/usr/include/zconf.h')
         f.fill(file_dict)
@@ -114,6 +124,10 @@ class TestClassFileData(unittest.TestCase):
                                      '6a10866e4ceeb204f7c3b6599834c7319541')
         self.assertEqual(f.extattrs, '-rw-r--r-- 1 1000 1000 '
                                      '16262 Nov 13 17:57 /usr/include/zconf.h')
+        self.assertEqual(f.checksums,
+                         [('SHA1', '12345abcde'),
+                          ('MD5', '1ff38cc592c4c5d0c8e3ca38be8f1eb1')]
+                         )
         self.assertEqual(f.origins.origins[0].notices[1].message,
                          'No metadata for key: file_type')
         self.assertEqual(f.origins.origins[0].notices[1].level, 'warning')
@@ -127,6 +141,8 @@ class TestClassFileData(unittest.TestCase):
         file1.set_checksum('sha256', '123abc456def')
         file1.extattrs = '-rwxr-xr-x|1000|1000|14408|1'
         file2 = FileData('switch_root', 'sbin/switch_root')
+        file2.checksums = [('SHA1', '12345abcde'),
+                           ('MD5', '1ff38cc592c4c5d0c8e3ca38be8f1eb1')]
         file2.set_checksum('sha256', '123abc456def')
         file2.extattrs = '-rwxr-xr-x|1000|1000|14408|1'
         file2.date = '2012-02-02'
@@ -148,6 +164,9 @@ class TestClassFileData(unittest.TestCase):
         self.assertEqual(file1.extattrs, '-rwxr-xr-x|1000|1000|14408|1')
         self.assertFalse(file1.merge('astring'))
         self.assertTrue(file1.merge(file2))
+        self.assertEqual(file1.checksums,
+                         [('SHA1', '12345abcde'),
+                          ('MD5', '1ff38cc592c4c5d0c8e3ca38be8f1eb1')])
         self.assertEqual(file1.date, '2012-02-02')
         self.assertEqual(file1.file_type, 'binary')
         self.assertEqual(file1.licenses, ['MIT', 'GPL'])


### PR DESCRIPTION
This PR adds checksums property to the FileData class.
It adds the add_checksums method to add new checksum tuples.
The tests have been added for the changes made.

Closes https://github.com/vmware/tern/issues/591

Signed-off-by: PrajwalM2212 <prajwalmmath@gmail.com>