### PR TITLE
Add dockerfile lock functionality to Tern

### DIFF
--- a/tern/analyze/common.py
+++ b/tern/analyze/common.py
@@ -372,15 +372,24 @@ def remove_unrecognized_commands(command_list):
 
 def consolidate_commands(command_list):
     '''Given a list of Command objects, consolidate the install and remove
-    commands into one and return a list of resulting command objects'''
+    commands into one install command and return a list of resulting
+    command objects'''
     new_list = []
+
+    if len(command_list) == 1:
+        new_list.append(command_list.pop(0))
+
     while command_list:
         first = command_list.pop(0)
         for _ in range(0, len(command_list)):
             second = command_list.pop(0)
-            if not first.merge(second):
-                command_list.append(first)
-        new_list.append(first)
+            if first.is_remove() and second.is_install():
+                # if remove then install, ignore the remove command
+                new_list.append(second)
+            else:
+                if not first.merge(second):
+                    command_list.append(first)
+                new_list.append(first)
     return new_list
 
 

--- a/tern/analyze/docker/container.py
+++ b/tern/analyze/docker/container.py
@@ -115,7 +115,7 @@ def get_image_digest(docker_image):
 def build_container(dockerfile, image_tag_string):
     '''Invoke docker command to build a docker image from the dockerfile
     It is assumed that docker is installed and the docker daemon is running'''
-    path = os.path.dirname(dockerfile)
+    path = os.path.dirname(os.path.abspath(dockerfile))
     if not check_image(image_tag_string):
         # let docker handle the errors
         client.images.build(path=path, tag=image_tag_string, nocache=True)

--- a/tern/analyze/docker/run.py
+++ b/tern/analyze/docker/run.py
@@ -103,7 +103,7 @@ def execute_docker_image(args):
         report.clean_working_dir()
 
 
-def execute_dockerfile(args):
+def execute_dockerfile(args):  # noqa C901,R0912
     '''Execution path if given a dockerfile'''
     container.check_docker_setup()
     logger.debug('Setting up...')

--- a/tern/command_lib/command_lib.py
+++ b/tern/command_lib/command_lib.py
@@ -290,3 +290,13 @@ def check_os_guess(binary):
         return ', '.join(os_list)
     except KeyError:
         return ''
+
+
+def check_pinning_separator(binary):
+    '''Given a binary package manager, return the associated pinning_separator
+    from base.yml. If the binary is not valid in base.yml, return an empty
+    string.'''
+    try:
+        return command_lib['base'][binary]['pinning_separator']
+    except KeyError:
+        return ''

--- a/tern/utils/constants.py
+++ b/tern/utils/constants.py
@@ -47,3 +47,5 @@ workdir = 'workdir'
 mergedir = 'mergedir'
 # report file
 report_file = 'report.txt'
+# locked dockerfile
+locked_dockerfile = 'Dockerfile.lock'


### PR DESCRIPTION
This is a series of commits that adds dockerfile lock functionality to Tern. The following is a list of highlights in the commit:

```
   - tern/analyze/common.py
      Add functionality to consolidate_commands() to handle the case when
      remove command precedes install in a dockerfile RUN line.
    
    - tern/analyze/docker/analyze.py
      Add functionality in analyze_subsequent_layers() to handle when a
      dockerfile object gets passed in as a parameter. When this happens,
      pin packages to their version for the RUN line that corresponds
      to the current image layer.
    
    - tern/analyze/docker/dockerfile.py
      Add 5 supporting functions to enable dockerfile lock functionality.
      1) expand_package()
         Update the provided dockerfile object with a pinned package
         version and name.
      2) get_run_layers()
         Helper function used in analyze.py that will collect a list of
         RUN commands from a given dockerfile object.
      3) package_in_dockerfile()
         Takes in a package name and command dictionary from a dfobj as
         parameters. Returns true if the package is specified in the
         command dictionary provided and false otherwise.
      4) create_locked_dockerfile()
         Calls upon the available "expand" functions in dockerfile.py
         to pin as much of the dockerfile object as possible. Then,
         writes and returns the dfobj strucutre content fields in a
         string.
      5) write_locked_dockerfile()
         Writes the pinned dockerfile to an actual file that the caller
         can access.

   - tern/analyze/docker/run.py
     enable dockerfile lock to utilize exisitng functionality in the
     execute_dockerfile() function. If the dockerfile lock command line
     option is envoked, the dockerfile object will be created in
     execute_dockerfile() so that it an be passed to analyze() to pin
     the packages by layer, and also be printed to the output file at
     the end of execute_dockerfile.

   - tern/__main__.py
    Add a new parser named 'lock' to Tern's command line
    options. It also updates some of the logic in tern/__main__.py to
    account for the new parser.
```

Works towards #454 

Signed-off-by: Rose Judge <rjudge@vmware.com>