### PR TITLE
Include file level licenses in the default report

### DIFF
--- a/tern/report/formats.py
+++ b/tern/report/formats.py
@@ -46,6 +46,7 @@ package_license = '''License: {package_license}\n'''
 package_copyright = '''Copyright Text: {package_copyright}\n'''
 layer_packages_list = '''\tPackages found in Layer:  {list}\n'''
 layer_licenses_list = '''\tLicenses found in Layer:  {list}\n'''
+layer_file_licenses_list = '''\tFile licenses found in Layer:  {list}\n'''
 full_licenses_list = '''###########################################\n'''\
     '''# Summary of licenses found in Container: #\n'''\
     '''###########################################\n{list}\n'''


### PR DESCRIPTION
This PR does following,

1. It Includes licenses found by scancode (if any) into
the default report format.

2. It adds `layer_file_licenses_list` message string to be
included into default report.

Resolved: #584

Signed-off-by: mukultaneja <mukultaneja91@gmail.com>