### PR TITLE
analyze: docker: Check cache before finding shell

### DIFF
--- a/tern/analyze/docker/analyze.py
+++ b/tern/analyze/docker/analyze.py
@@ -84,17 +84,21 @@ def abort_analysis():
 
 
 def analyze_first_layer(image_obj, master_list, redo):
-    # find the binary and shell by mounting the base layer
-    target = rootfs.mount_base_layer(image_obj.layers[0].tar_file)
-    binary = common.get_base_bin()
-    shell = get_shell(image_obj, binary)
-    # set up a notice origin for the first layer
-    origin_first_layer = 'Layer: ' + image_obj.layers[0].fs_hash[:10]
-    # only extract packages if there is a known binary and the layer is not
-    # cached
-    if binary:
-        if not common.load_from_cache(image_obj.layers[0], redo):
-            # Determine pacakge/os style from binary in the image layer
+    # set shell to empty string in case one is found
+    shell = ''
+    # try to load from cache
+    loaded = common.load_from_cache(image_obj.layers[0], redo)
+    # if there is no cache, find the binary and shell by mounting the
+    # base layer
+    if not loaded:
+        target = rootfs.mount_base_layer(image_obj.layers[0].tar_file)
+        binary = common.get_base_bin()
+        shell = get_shell(image_obj, binary)
+        # set up a notice origin for the first layer
+        origin_first_layer = 'Layer: ' + image_obj.layers[0].fs_hash[:10]
+        # only extract packages if there is a known binary
+        if binary:
+            # Determine package/os style from binary in the image layer
             common.get_os_style(image_obj.layers[0], binary)
             # get the packages of the first layer
             try:
@@ -105,17 +109,18 @@ def analyze_first_layer(image_obj, master_list, redo):
                 abort_analysis()
             # unmount proc, sys and dev
             rootfs.undo_mount()
-    else:
-        logger.warning(errors.no_package_manager)
-        # /etc/os-release may still be present even if binary is not
-        common.get_os_style(image_obj.layers[0], None)
-        image_obj.layers[0].origins.add_notice_to_origins(
-            origin_first_layer, Notice(errors.no_package_manager, 'warning'))
-        # no binary means there is no shell so set to default shell
-        logger.warning('Unknown filesystem. Using default shell')
-        shell = constants.shell
-    # unmount the first layer
-    rootfs.unmount_rootfs()
+        else:
+            logger.warning(errors.no_package_manager)
+            # /etc/os-release may still be present even if binary is not
+            common.get_os_style(image_obj.layers[0], None)
+            image_obj.layers[0].origins.add_notice_to_origins(
+                origin_first_layer, Notice(
+                    errors.no_package_manager, 'warning'))
+            # no binary means there is no shell so set to default shell
+            logger.warning('Unknown filesystem. Using default shell')
+            shell = constants.shell
+        # unmount the first layer
+        rootfs.unmount_rootfs()
     # populate the master list with all packages found in the first layer
     for p in image_obj.layers[0].packages:
         master_list.append(p)
@@ -126,7 +131,8 @@ def analyze_subsequent_layers(image_obj, shell, master_list, redo, dfobj=None): 
     # get packages for subsequent layers
     curr_layer = 1
     while curr_layer < len(image_obj.layers):  # pylint:disable=too-many-nested-blocks
-        if not common.load_from_cache(image_obj.layers[curr_layer], redo):
+        if (not common.load_from_cache(image_obj.layers[curr_layer], redo) and
+                shell):
             # get commands that created the layer
             # for docker images this is retrieved from the image history
             command_list = dhelper.get_commands_from_history(


### PR DESCRIPTION
For images that have their files analysed but don't have a shell
or package manager, the analysis will error out with the appropriate
message that a package manager or shell was not found. However, the
file level analysis still existed in the cache, so it should not
error out in this case. This commit fixes the error by checking
if loading from the cache was successful first. Consequently, it
also checks to see if a shell was returned in the analysis of the
first layer so that analysis of subsequent layers can proceed only
if there is no cached data and there is a shell.

Signed-off-by: Nisha K <nishak@vmware.com>