### PR TITLE
Include base OS value in Tern's data model

### DIFF
--- a/tern/analyze/docker/analyze.py
+++ b/tern/analyze/docker/analyze.py
@@ -94,12 +94,17 @@ def analyze_first_layer(image_obj, master_list, redo):
         target = rootfs.mount_base_layer(image_obj.layers[0].tar_file)
         binary = common.get_base_bin()
         shell = get_shell(image_obj, binary)
+        image_obj.layers[0].os_guess = common.get_os_release()
         # set up a notice origin for the first layer
         origin_first_layer = 'Layer: ' + image_obj.layers[0].fs_hash[:10]
         # only extract packages if there is a known binary
         if binary:
             # Determine package/os style from binary in the image layer
             common.get_os_style(image_obj.layers[0], binary)
+            # Update os_guess to default if /etc/os-release not available
+            if not image_obj.layers[0].os_guess:
+                image_obj.layers[0].os_guess = \
+                    command_lib.check_os_guess(binary)
             # get the packages of the first layer
             try:
                 rootfs.prep_rootfs(target)


### PR DESCRIPTION
This commit assigns an 'os_guess' value to the first image_layer
object in a container. If an /etc/os-release file is available
to pull the value from, this commtit will assign the PRETTY_NAME
value from this file to the first image_layer's 'os_guess' value.
If the /etc/os-release file is not available, it will represent
the list of os_guess values in base.yml as a comma-separated string.

Resolves #524

Signed-off-by: Rose Judge <rjudge@vmware.com>