### PR TITLE
Replace manual Dockerfile parser with dockerfile-parse

### DIFF
--- a/tern/analyze/docker/dockerfile.py
+++ b/tern/analyze/docker/dockerfile.py
@@ -130,6 +130,20 @@ def expand_arg(dfobj):
     if arg_dict:
         for obj in dfobj.structure:
             replace_env(arg_dict, obj)
+    # Update dfobj parent image just in case ARG value was used in FROM line
+    update_parent_images(dfobj)
+
+
+def update_parent_images(dfobj):
+    '''Given a Dockerfile object, update the parent_images list. This function
+    will be useful after ARG values have been replaced in expand_arg() that
+    can sometimes affect the FROM line(s) of a Dockerfile.'''
+    new_parent_list = []
+    for cmd_dict in dfobj.structure:
+        if cmd_dict['instruction'] == 'FROM':
+            new_parent_list.append(re.split(" as", cmd_dict['value'],
+                                            flags=re.IGNORECASE)[0])
+    dfobj.parent_images = new_parent_list
 
 
 def parse_from_image(dfobj):
@@ -204,117 +218,15 @@ def package_in_dockerfile(command_dict, pkg_name):
     return False
 
 
-def get_command_list(dockerfile_name):
-    '''Given a Dockerfile, return a list of Docker commands'''
-    with open(dockerfile_name) as f:
-        contents = f.read()
-    dockerfile_lines = contents.split('\n')
-    command_list = []
-    command = ''
-    command_cont = False
-    for line in dockerfile_lines:
-        # check if this line is a continuation of the previous line
-        # it should not be a comment
-        if command_cont:
-            if comments.match(line) is not None:
-                command = command + line
-        # check if this line has an indentation
-        # comments don't count
-        command_cont = bool(line_indent.match(line))
-
-        # check if there is a command or not
-        if command == '':
-            directive = line.split(' ', 1)[0]
-            if directive in directives:
-                command = line
-        # check if there is continuation or not and if the command is still
-        # non-empty
-        if not command_cont and command != '':
-            command_list.append(command)
-            command = ''
-
-    return command_list
-
-
-def get_directive(line):
-    '''Given a line from a Dockerfile get the Docker directive
-    eg: FROM, ADD, COPY, RUN and the object in the form of a tuple'''
-    directive_and_action = line.split(' ', 1)
-    return (directive_and_action[0], directive_and_action[1])
-
-
-def get_directive_list(command_list):
-    '''Given a list of docker commands extracted from a Dockerfile,
-    provide a list of tuples containing the Docker directive
-    i.e. FROM, ADD, COPY etc and the object to be acted upon'''
-    directive_list = []
-    for command in command_list:
-        directive_list.append(get_directive(general.clean_command(command)))
-    return directive_list
-
-
-def get_base_instructions(instructions):
-    '''Given a list of docker build instructions get a list of instructions
-    related to the base instructions
-    Possible docker instructions related to the base image:
-        FROM <base image>
-
-        FROM <image:tag>
-
-        ARG <key value pair>
-        FROM <key>
-
-    Dockerfile rules say that the only instruction that can precede FROM is
-    ARG'''
-    base_instructions = []
-    # check if the first instruction is FROM
-    if instructions[0][0] == 'FROM':
-        base_instructions.append(instructions[0])
-    # check if the first instruction is ARG
-    if instructions[0][0] == 'ARG':
-        # collect all ARGS until FROM
-        count = 0
-        while instructions[count][0] != 'FROM':
-            base_instructions.append(instructions[count])
-            count = count + 1
-        # get the form statement
-        base_instructions.append(instructions[count])
-    return base_instructions
-
-
-def get_base_image_tag(base_instructions):
-    '''Given the base docker instructions, return the base image and tag
-    as a tuple
-    This involves finding the ARG key value pair and then replacing it
-    if it occurs in the image part
-    NOTE: Dockerfile rules say that if no --build-arg is passed during
-    docker build and ARG has no default, the build will fail. We assume
-    for now that we will not be passing build arguments in which case
-    if there is no default ARG, we will raise an exception indicating that
-    since the build arguments are determined by the user we will not
-    be able to determine what the user wanted'''
-    # get all the ARG key-value pairs
-    build_args = {}
-    from_instruction = ''
-    for instruction in base_instructions:
-        if instruction[0] == 'FROM':
-            from_instruction = instruction[1]
-        else:
-            key_value = instruction[1].split('=')
-            # raise error if there is no default value
-            if len(key_value) == 1:
-                raise ValueError('No ARG default value.'
-                                 ' Unable to determine base image')
-            build_args.update({key_value[0]: key_value[1]})
-    # replace any variables in FROM with value
-    from_instruction = re.sub(bash_var, '', from_instruction)
-    for key, value in build_args.items():
-        from_instruction = from_instruction.replace(key, value)
-    # check if the base image has a tag
-    image_tag_list = from_instruction.split(tag_separator)
-    if len(image_tag_list) == 1:
-        image_tag_list.append('')
-    return tuple(image_tag_list)
+def get_command_list(dfobj_structure):
+    '''Given a dockerfile object structure, return the list of commands
+    from the list of dictionaries. Useful when you don't want to loop
+    through the dictionary for commands'''
+    cmd_list = []
+    for cmd_dict in dfobj_structure:
+        if cmd_dict['instruction'] != 'COMMENT':
+            cmd_list.append(cmd_dict['content'].rstrip())
+    return cmd_list
 
 
 def find_git_info(line, dockerfile_path):
@@ -361,10 +273,8 @@ def expand_add_command(dfobj):
 def create_locked_dockerfile(dfobj):
     '''Given a dockerfile object, the information in a new Dockerfile object
     Copy the dfobj info to the destination output Dockerfile location'''
+    # packages in RUN lines, ENV, and ARG values are already expanded
     expand_from_images(dfobj)
-    # packages in run lines are already expanded
-    expand_vars(dfobj)
-    expand_arg(dfobj)
     expand_add_command(dfobj)
     # create the output file
     dfile = ''

--- a/tern/analyze/docker/helpers.py
+++ b/tern/analyze/docker/helpers.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2017-2020 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
 """
@@ -11,6 +11,7 @@ import docker
 import logging
 import os
 import re
+import sys
 
 from tern.classes.docker_image import DockerImage
 from tern.classes.notice import Notice
@@ -20,6 +21,7 @@ from tern.utils import constants
 from tern.report import errors
 from tern.report import formats
 from tern.analyze import common
+from tern.utils.general import check_image_string
 
 # dockerfile
 dockerfile_global = ''
@@ -30,25 +32,14 @@ docker_commands = []
 logger = logging.getLogger(constants.logger_name)
 
 
-def load_docker_commands(dockerfile_path):
-    '''Given a dockerfile get a persistent list of docker commands'''
-    if not os.path.isfile(dockerfile_path):
-        raise IOError('{} does not exist'.format(dockerfile_path))
+def load_docker_commands(dfobj):
+    '''Given a dockerfile object get a persistent list of docker commands'''
+    if not os.path.isfile(dfobj.filepath):
+        raise IOError('{} does not exist'.format(dfobj.filepath))
     global docker_commands
-    docker_commands = dockerfile.get_directive_list(
-        dockerfile.get_command_list(dockerfile_path))
+    docker_commands = dfobj.structure
     global dockerfile_global
-    dockerfile_global = dockerfile_path
-
-
-def print_dockerfile_base(base_instructions):
-    '''For the purpose of tracking the lines in the dockerfile that
-    produce packages, return a string containing the lines in the dockerfile
-    that pertain to the base image'''
-    base_instr = ''
-    for instr in base_instructions:
-        base_instr = base_instr + instr[0] + ' ' + instr[1]
-    return base_instr
+    dockerfile_global = dfobj.filepath
 
 
 def get_dockerfile_base():
@@ -56,42 +47,60 @@ def get_dockerfile_base():
     1. get the instructions around FROM
     2. get the base image and tag
     3. Make notes based on what the image and tag rules are
-    4. Return an image object and the base instructions string'''
+    4. Return an image object and the base instructions string
+    NOTE: Potential ARG values in the Dockerfile object have already been
+    expanded at this point. However, Dockerfile rules say that if no
+    --build-arg is passed during docker build and ARG has no default, the
+    build will fail. We assume for now that we will not be passing build
+    arguments in which case if there is no default ARG, we will raise an
+    exception indicating that since the build arguments are determined by
+    the user we will not be able to determine what the user wanted'''
     try:
-        base_instructions = dockerfile.get_base_instructions(docker_commands)
-        base_image_tag = dockerfile.get_base_image_tag(base_instructions)
-        dockerfile_lines = print_dockerfile_base(base_instructions)
+        dockerfile_lines = docker_commands
+        base_image_string = ''
+        from_line = ''
+        # Get the base image tag.
+        # NOTE: ARG values have already been expanded.
+        for i, cmd_dict in enumerate(dockerfile_lines):
+            if cmd_dict['instruction'] == 'FROM':
+                # Account for "as" keyword in FROM line
+                base_image_string = re.split(" as", cmd_dict['value'],
+                                             flags=re.IGNORECASE)[0]
+                from_line = 'FROM' + base_image_string
+                # Check that potential ARG values has default
+                if i != 0 and dockerfile_lines[i-1]['instruction'] == 'ARG':
+                    if len(dockerfile_lines[i-1]['value'].split('=')) == 1:
+                        raise ValueError('No ARG default value to pass to '
+                                         'FROM command in Dockerfile.')
+                break
         # check for scratch
-        if base_image_tag[0] == 'scratch':
-            # there is no base image - return no image object
-            return None, None
+        if base_image_string == 'scratch':
+            # there is no base image to pull
+            raise ValueError("Cannot pull 'scratch' base image.")
         # there should be some image object here
-        repotag = base_image_tag[0] + dockerfile.tag_separator + \
-            base_image_tag[1]
-        from_line = 'FROM ' + repotag
-        base_image = DockerImage(repotag)
-        base_image.origins.add_notice_origin(dockerfile_lines)
-        base_image.name = base_image_tag[0]
+        base_image = DockerImage(base_image_string)
+        base_image.origins.add_notice_origin(from_line)
+        base_image.name = base_image_string.split(':')[0]
         # check if there is a tag
-        if not base_image_tag[1]:
+        if not check_image_string(base_image_string):
             message_string = errors.dockerfile_no_tag.format(
                 dockerfile_line=from_line)
             base_image.origins.add_notice_to_origins(
                 dockerfile_lines, Notice(message_string, 'warning'))
             base_image.tag = 'latest'
         else:
-            base_image.tag = base_image_tag[1]
+            base_image.tag = base_image_string.split(':')[1]
         # check if the tag is 'latest'
-        if base_image_tag[1] == 'latest':
+        if base_image.tag == 'latest':
             message_string = errors.dockerfile_using_latest.format(
                 dockerfile_line=from_line)
             base_image.origins.add_notice_to_origins(
                 dockerfile_lines, Notice(message_string, 'warning'))
-        return base_image, dockerfile_lines
+        return base_image, from_line
     except ValueError as e:
-        logger.warning("%s", errors.cannot_parse_base_image.format(
+        logger.fatal("%s", errors.cannot_parse_base_image.format(
             dockerfile=dockerfile_global, error_msg=e))
-        return None, None
+        sys.exit(1)
 
 
 def get_dockerfile_image_tag():
@@ -167,16 +176,17 @@ def set_imported_layers(docker_image):
     '''Given a Docker image object that was built from a Dockerfile, set the
     layers that were imported using the Dockerfile's FROM command or the ones
     that came before it'''
-    dockerfile_lines = dockerfile.get_command_list(dockerfile_global)
     index = -1
     from_line = ''
-    for line in dockerfile_lines:
-        if 'FROM' in line:
-            from_line = line
+    dockerfile_lines = docker_commands
+    for cmd in dockerfile_lines:
+        if cmd['instruction'] == 'FROM':
+            from_line = cmd['content'].rstrip()
             break
+    command_list = dockerfile.get_command_list(dockerfile_lines)
     for layer in docker_image.layers:
         instr = created_to_instruction(layer.created_by)
-        if instr in dockerfile_lines:
+        if instr in command_list:
             index = docker_image.layers.index(layer)
             break
     if index != -1:

--- a/tern/report/errors.py
+++ b/tern/report/errors.py
@@ -65,7 +65,7 @@ dockerfile_no_tag = '''The Dockerfile provided has no tag in the line ''' \
 dockerfile_using_latest = '''The Dockerfile is using the tag 'latest' ''' \
     '''in line {dockerfile_line}. Consider using a specific immutable tag'''
 cannot_parse_base_image = '''Unable to parse base image in the Dockerfile ''' \
-    '''{dockerfile}. Error: {error_msg}\n'''
+    ''''{dockerfile}'. Error: {error_msg}\n'''
 base_image_not_found = '''Failed to pull the base image. Perhaps it was ''' \
     '''removed from Dockerhub\n'''
 cannot_extract_base_image = '''Failed to extact base image {image}:{tag}.'''

--- a/tern/report/report.py
+++ b/tern/report/report.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2017-2020 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
 """
@@ -41,15 +41,15 @@ def write_report(report, args):
         f.write(report)
 
 
-def setup(dockerfile=None, image_tag_string=None):
+def setup(dfobj=None, image_tag_string=None):
     '''Any initial setup'''
     # generate random names for image, container, and tag
     general.initialize_names()
     # load the cache
     cache.load()
     # load dockerfile if present
-    if dockerfile:
-        dhelper.load_docker_commands(dockerfile)
+    if dfobj is not None:
+        dhelper.load_docker_commands(dfobj)
     # check if the docker image is present
     if image_tag_string and general.check_tar(image_tag_string) is False:
         if container.check_image(image_tag_string) is None:


### PR DESCRIPTION
This is a large commit that removes unnecessary manual parsing from
tern/analyze/docker/dockerfile.py so that other parts of the code can
utilize the built-in parsing abilities from the DockerfileParse module.
While a majority of the changes are in dockerfile.py, there are a
handful of other files modified as a result of the changes to
dockerfile.py.

Resolves #522 

Signed-off-by: Rose Judge <rjudge@vmware.com>