### PR TITLE
Fix file and base OS caching

### DIFF
--- a/tern/analyze/common.py
+++ b/tern/analyze/common.py
@@ -125,13 +125,13 @@ def save_to_cache(image):
             cache.add_layer(layer)
 
 
-def get_base_bin():
-    '''Given the base layer object, find the binary used to identify the
-    base OS layer. Assume that the layer filesystem is mounted'''
+def get_base_bin(first_layer):
+    '''Find the binary used to identify the base OS for the container image.
+    We do this by providing the path to the first layer of the container
+    image and looking for known binaries there. Assume that the layer has
+    already been unpacked with the filesystem'''
     binary = ''
-    # the path to where the filesystem is mounted
-    # look at utils/rootfs.py mount_base_layer module
-    cwd = os.path.join(rootfs.get_working_dir(), constants.mergedir)
+    cwd = rootfs.get_untar_dir(first_layer.tar_file)
     for key, value in command_lib.command_lib['base'].items():
         for path in value['path']:
             if os.path.exists(os.path.join(cwd, path)):

--- a/tern/analyze/common.py
+++ b/tern/analyze/common.py
@@ -47,14 +47,12 @@ def load_from_cache(layer, redo=False):
         # check if packages are available in the cache
         if load_packages_from_cache(layer):
             loaded = True
-        # check if files are available in the cache
-        if load_files_from_cache(layer):
-            loaded = True
         # load some extra properties into the layer if available
         if layer.fs_hash in cache.get_layers():
             layer.files_analyzed = cache.cache[layer.fs_hash]['files_analyzed']
             # load any origin data
             load_notices_from_cache(layer)
+        load_files_from_cache(layer)
     return loaded
 
 
@@ -82,7 +80,6 @@ def load_packages_from_cache(layer):
 
 def load_files_from_cache(layer):
     '''Given a layer object, populate file level information'''
-    loaded = False
     raw_file_list = cache.get_files(layer.fs_hash)
     if raw_file_list:
         logger.debug(
@@ -98,13 +95,11 @@ def load_files_from_cache(layer):
                             origin_dict['origin_str'], Notice(
                                 notice['message'], notice['level']))
             layer.add_file(f)
-            loaded = True
     else:
         # if there are no files, generate them from the pre-calculated
         # hash file
         logger.debug('Reading files in filesystem...')
         layer.add_files()
-    return loaded
 
 
 def load_notices_from_cache(layer):

--- a/tern/utils/cache.py
+++ b/tern/utils/cache.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017-2019 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2017-2020 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
 """
@@ -60,8 +60,9 @@ def get_layers():
 
 def get_origins(layer_hash):
     '''Return the origins dictionary'''
-    if 'origins' in cache[layer_hash].keys():
-        return cache[layer_hash]['origins']
+    if layer_hash in get_layers():
+        if 'origins' in cache[layer_hash].keys():
+            return cache[layer_hash]['origins']
     return []
 
 


### PR DESCRIPTION
These commits bring in changes to fix caching of file and layer
information introduced by including file level information into the
analysis.

For images that have their files analyzed but don't have a shell
or package manager, the analysis will error out with the appropriate
message that a package manager or shell was not found. However, the
file level analysis still existed in the cache, so it should report that
information. In order to not interfere with the package level caching and
reporting, several changes needed to be brought in:

The first commit allows finding a known binary in the base OS image
without mounting it.
The second commit makes sure the binary and the shell are known
before trying to load from the cache.
The third commit fixes a bug where multiple copies of the same notice
get recorded.
The fourth commit makes modification to the retrieval of the base OS
image information by making sure the appropriate checks are made
in one function get_os_style. This also includes changes to make sure
get_os_release does not need a base OS layer to be mounted.

The dates on the copyright notices were also updated.

Signed-off-by: Nisha K <nishak@vmware.com>