### PR TITLE
Except 'NotFound' error if FROM image DNE

### DIFF
--- a/tern/analyze/docker/container.py
+++ b/tern/analyze/docker/container.py
@@ -91,7 +91,7 @@ def pull_image(image_tag_string):
         image = client.images.pull(image_tag_string)
         logger.debug("Image \"%s\" downloaded", image_tag_string)
         return image
-    except docker.errors.ImageNotFound:
+    except (docker.errors.ImageNotFound, docker.errors.NotFound):
         logger.warning("No such image: \"%s\"", image_tag_string)
         return None
 


### PR DESCRIPTION
Currently when running Tern with a Dockerfile, if the FROM 'image:tag'
does not exist, there is a long Traceback output. This commit adds the
'docker.errors.NotFound: 404 Client Error' error as an exception in the
pull_image() function in tern/analyze/docker/container.py so that Tern
fails more gracefully while still reporting the error.

Resolves #610

Signed-off-by: Rose Judge <rjudge@vmware.com>