### PR TITLE
Preserve newline characters in Dockerfile.lock

### DIFF
--- a/tern/analyze/docker/dockerfile.py
+++ b/tern/analyze/docker/dockerfile.py
@@ -276,10 +276,20 @@ def create_locked_dockerfile(dfobj):
     # packages in RUN lines, ENV, and ARG values are already expanded
     expand_from_images(dfobj)
     expand_add_command(dfobj)
+
     # create the output file
     dfile = ''
+    prev_endline = 0
+
     for command_dict in dfobj.structure:
-        dfile = dfile + command_dict['content']
+        endline = command_dict["endline"]
+        diff = endline - prev_endline
+        # calculate number of new line characters to
+        # add before each line of content
+        delimeter = "\n" * (diff - 1) if diff > 1 else ""
+        dfile = dfile + delimeter + command_dict['content']
+        prev_endline = endline
+
     return dfile
 
 


### PR DESCRIPTION
This PR does following,

1. It includes New lines in Dockerfile lock command and
make the resulting locked dockerfile look cleaner

Resolved: #596

Signed-off-by: mukultaneja <mtaneja@vmware.com>