### PR TITLE
Add exception for raw container image teardown

### DIFF
--- a/tern/analyze/docker/container.py
+++ b/tern/analyze/docker/container.py
@@ -188,7 +188,7 @@ def close_client():
     used after analysis is done'''
     try:
         client.close()
-    except requests.exceptions.ConnectionError:
-        # it should either already be closed or docker is not setup
-        # either way, the socket is closed
+    except (AttributeError, requests.exceptions.ConnectionError):
+        # it should either already be closed, no socker is in use,
+        # or docker is not setup -- either way, the socket is closed
         pass


### PR DESCRIPTION
The `close_client()` method that gets called as a part of image teardown
after Tern analysis ends the docker interactions by closing the
client. However, if Tern is run with a raw container image tarball,
there is no client to close and therefore, Tern throws an
`AttributeError` as the client type is None.

This commit adds `AttributeError` as an exception to be
caught in the `close_client()` method so that an output report is properly
generated when Tern is run with a raw container image.

Resolves #628

Signed-off-by: Rose Judge <rjudge@vmware.com>