### PR TITLE
Increase timeout for pulling large images

### DIFF
--- a/tern/analyze/docker/container.py
+++ b/tern/analyze/docker/container.py
@@ -38,7 +38,7 @@ def check_docker_setup():
     appropriate privileges'''
     global client
     try:
-        client = docker.from_env()
+        client = docker.from_env(timeout=120)
         client.ping()
     except requests.exceptions.ConnectionError as e:
         logger.critical('Critical Docker error: %s', str(e))


### PR DESCRIPTION
Container images on the order of GBs were failing to be converted to
tarballs via the client.api.get_image() command as the client read
timeout was set to the default value of 60 seconds. Increasing the
timeout to 120 seconds gives the docker python API ample time to
load the image and for Tern to continue with analysis as expected.

Resolves #630

Signed-off-by: Rose Judge <rjudge@vmware.com>